### PR TITLE
API: User Management & Authentication

### DIFF
--- a/.redocly.lint-ignore.yaml
+++ b/.redocly.lint-ignore.yaml
@@ -1,0 +1,58 @@
+# This file instructs Redocly's linter to ignore the rules contained for specific parts of your API.
+# See https://redoc.ly/docs/cli/ for more information.
+openapi/karman.yaml:
+  spec:
+    - >-
+      #/components/securitySchemes/OAuth2/flows/urn:ietf:params:oauth:grant-type:token-exchange
+openapi/tags/auth.yaml:
+  operation-4xx-problem-details-rfc7807:
+    - '#/components/responses/TokenError'
+  path-segment-plural:
+    - '#/paths/~1auth~1token'
+openapi/tags/songs.yaml:
+  operation-4xx-problem-details-rfc7807:
+    - '#/components/schemas/SongNotFoundError/allOf/1/properties/type'
+    - '#/components/schemas/SongNotFoundError/allOf/1/properties/title'
+    - >-
+      #/components/responses/UploadSongCannotBeModified/content/application~1problem+json/schema/allOf/1/properties/type
+    - >-
+      #/components/responses/UploadSongCannotBeModified/content/application~1problem+json/schema/allOf/1/properties/title
+    - '#/components/schemas/InvalidTXTError/allOf/1/properties/type'
+    - '#/components/schemas/InvalidTXTError/allOf/1/properties/title'
+openapi/tags/media.yaml:
+  operation-4xx-problem-details-rfc7807:
+    - '#/components/schemas/FileNotFoundError/allOf/1/properties/type'
+    - '#/components/schemas/FileNotFoundError/allOf/1/properties/title'
+openapi/common/problem-details.yaml:
+  operation-4xx-problem-details-rfc7807:
+    - >-
+      #/components/responses/UnprocessableEntity/content/application~1problem+json/schema/allOf/1/properties/type
+    - >-
+      #/components/responses/UnprocessableEntity/content/application~1problem+json/schema/allOf/1/properties/title
+openapi/tags/uploads.yaml:
+  operation-4xx-problem-details-rfc7807:
+    - '#/components/schemas/UploadNotFoundError/allOf/1/properties/type'
+    - '#/components/schemas/UploadNotFoundError/allOf/1/properties/title'
+    - >-
+      #/components/responses/InvalidPathOrUUID/content/application~1problem+json/schema/oneOf/1/allOf/1/properties/type
+    - >-
+      #/components/responses/InvalidPathOrUUID/content/application~1problem+json/schema/oneOf/1/allOf/1/properties/title
+    - >-
+      #/components/responses/FileOrUploadNotFound/content/application~1problem+json/schema/oneOf/1/allOf/1/properties/type
+    - >-
+      #/components/responses/FileOrUploadNotFound/content/application~1problem+json/schema/oneOf/1/allOf/1/properties/title
+    - '#/components/responses/UploadStateError'
+openapi/tags/user.yaml:
+  operation-4xx-problem-details-rfc7807:
+    - >-
+      #/components/responses/UsernameNotAvailable/content/application~1problem+json/schema/allOf/1/properties/type
+    - >-
+      #/components/responses/UsernameNotAvailable/content/application~1problem+json/schema/allOf/1/properties/title
+    - >-
+      #/components/responses/UserNotFound/content/application~1problem+json/schema/allOf/1/properties/type
+    - >-
+      #/components/responses/UserNotFound/content/application~1problem+json/schema/allOf/1/properties/title
+    - >-
+      #/paths/~1v1~1users~1{id}~1email/post/responses/409/content/application~1problem+json/schema/allOf/1/properties/type
+    - >-
+      #/paths/~1v1~1users~1{id}~1email/post/responses/409/content/application~1problem+json/schema/allOf/1/properties/title

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@ build/openapi.yaml: .redocly.yaml $(OPENAPI_FILES)
 	@echo "Build OpenAPI Document"
 	@redocly join --output "$@" $(OPENAPI_SPECS)
 	@echo "Inserting Tag Groups"
-	@yq -i '.x-tagGroups = ($(shell yq -j .x-tagGroups < ./openapi/karman.yaml))' "$@"
+	@yq -i '.x-tagGroups = ($(shell yq -o=json .x-tagGroups < ./openapi/karman.yaml))' "$@"
+	@yq -i '.security = ($(shell yq -o=json .security < ./openapi/karman.yaml))' "$@"
 
 build/openapi.html: build/openapi.yaml
 	@echo "Build HTML Documentation"

--- a/openapi/common/pagination.yaml
+++ b/openapi/common/pagination.yaml
@@ -2,7 +2,11 @@ openapi: 3.0.3
 info:
   title: Pagination Schema
   version: v1
+
+
 paths: {}
+
+
 components:
   parameters:
     limit:
@@ -23,6 +27,7 @@ components:
         minimum: 0
         maximum: 100
         example: 50
+
     offset:
       in: query
       name: offset
@@ -36,6 +41,8 @@ components:
         default: 0
         minimum: 0
         example: 25
+
+
   headers:
     Pagination-Count:
       description: |-
@@ -45,6 +52,7 @@ components:
         type: integer
         example: 25
       required: true
+
     Pagination-Offset:
       description: |-
         The index of the first returned element within the collection of all result elements.
@@ -52,6 +60,7 @@ components:
         type: integer
         example: 513
       required: true
+
     Pagination-Limit:
       description: |-
         The result size limit specified in the request.
@@ -60,6 +69,7 @@ components:
         default: 25
         example: 35
       required: true
+
     Pagination-Total:
       description: |-
         The total number of elements in the result (not only the results contained in the items).

--- a/openapi/common/problem-details.yaml
+++ b/openapi/common/problem-details.yaml
@@ -62,6 +62,15 @@ components:
         instance: "/traces/481CF77B-3099-445C-A789-58F997233681"
       allOf:
         - $ref: "#/components/schemas/ProblemDetails"
+    EndpointDisabledError:
+      title: Endpoint Disabled
+      example:
+        type: "codello.dev/karman/problems/endpoint-disabled"
+        title: "Endpoint Disabled"
+        status: 403
+        detail: "This feature has been disabled by the server administrator."
+      allOf:
+        - $ref: "#/components/schemas/ProblemDetails"
   responses:
     BadRequest:
       x-summary: Bad Request

--- a/openapi/common/problem-details.yaml
+++ b/openapi/common/problem-details.yaml
@@ -2,7 +2,11 @@ openapi: 3.0.3
 info:
   title: Error Schemas
   version: v1
+
+
 paths: {}
+
+
 components:
   schemas:
     ProblemDetails:
@@ -13,6 +17,7 @@ components:
           Unless documented these additional fields should not be relied upon.
       description: |-
         A problem details object as specified in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      required: [ status ]
       properties:
         type:
           type: string
@@ -46,6 +51,7 @@ components:
             It may or may not yield further information if dereferenced.
             This field is usually absent but may be used for tracing information.
           example: "/traces/481CF77B-3099-445C-A789-58F997233681"
+
     InvalidUUIDError:
       title: Invalid UUID
       example:
@@ -54,6 +60,7 @@ components:
         status: 400
       allOf:
         - $ref: "#/components/schemas/ProblemDetails"
+
     BadRequestError:
       title: Bad Request Body
       example:
@@ -62,6 +69,18 @@ components:
         instance: "/traces/481CF77B-3099-445C-A789-58F997233681"
       allOf:
         - $ref: "#/components/schemas/ProblemDetails"
+
+    PermissionDeniedError:
+      title: PermissionDenied
+      example:
+        type: "codello.dev/karman/problems/permission-denied"
+        title: "Permission Denied"
+        status: 403
+        detail: "You must be an administrator to perform this action."
+      allOf:
+        - $ref: "#/components/schemas/ProblemDetails"
+
+
     EndpointDisabledError:
       title: Endpoint Disabled
       example:
@@ -71,6 +90,8 @@ components:
         detail: "This feature has been disabled by the server administrator."
       allOf:
         - $ref: "#/components/schemas/ProblemDetails"
+
+
   responses:
     BadRequest:
       x-summary: Bad Request
@@ -83,6 +104,7 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/BadRequestError"
+
     InvalidUUID:
       x-summary: Invalid UUID
       description: |-
@@ -91,6 +113,7 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/InvalidUUIDError"
+
     BadRequestOrInvalidUUID:
       x-summary: Bad Request
       description: |-
@@ -106,6 +129,37 @@ components:
             oneOf:
               - $ref: "#/components/schemas/BadRequestError"
               - $ref: "#/components/schemas/InvalidUUIDError"
+
+    Unauthorized:
+      x-summary: Unauthorized
+      description: |-
+        The endpoint requires authentication, but a valid authentication token was not provided.
+      headers:
+        WWW-Authenticate:
+          schema:
+            type: string
+            enum: [ "Bearer"]
+          description: |-
+            This header contains information about the supported authentication schemes for this endpoint.
+      content:
+        application/problem+json:
+          schema:
+            example:
+              title: "Unauthorized"
+              status: 401
+              instance: "/traces/481CF77B-3099-445C-A789-58F997233681"
+            allOf:
+              - $ref: "#/components/schemas/ProblemDetails"
+
+    PermissionDenied:
+      x-summary: Permission Denied
+      description: |-
+        This error indicates that the user performing the request does not have the required permissions.
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/PermissionDeniedError"
+
     UnprocessableEntity:
       x-summary: Unprocessable Entity
       description: |-
@@ -137,6 +191,7 @@ components:
                       A `Unprocessable Entity` response may or may not contain information about the JSON field that caused the error.
                       
                       The value of this property is a mapping from field paths to error messages.
+
     UnexpectedError:
       x-summary: Unexpected Error
       description: |-
@@ -151,6 +206,7 @@ components:
               instance: "/traces/481CF77B-3099-445C-A789-58F997233681"
             allOf:
               - $ref: "#/components/schemas/ProblemDetails"
+
     UnsupportedMediaType:
       x-summary: Unsupported Media Type
       description: |-

--- a/openapi/common/problem-details.yaml
+++ b/openapi/common/problem-details.yaml
@@ -124,18 +124,19 @@ components:
               title: "Unprocessable Entity"
               status: 422
               instance: "/traces/481CF77B-3099-445C-A789-58F997233681"
+              fields:
+                medley.medleyStartBeat: "number expected"
             allOf:
               - $ref: "#/components/schemas/ProblemDetails"
               - type: object
                 properties:
-                  field:
-                    type: string
-                    example: "medley.medleyStartBeat"
+                  fields:
+                    type: object
+                    additionalProperties: { type: string }
                     description: |-
                       A `Unprocessable Entity` response may or may not contain information about the JSON field that caused the error.
-                      The value of this property is the path to the field causing the error.
                       
-                      The `fields` object might contain a mapping from field paths to error messages.
+                      The value of this property is a mapping from field paths to error messages.
     UnexpectedError:
       x-summary: Unexpected Error
       description: |-

--- a/openapi/karman.yaml
+++ b/openapi/karman.yaml
@@ -86,3 +86,4 @@ components:
         password:
           tokenUrl: /auth/token
           refreshUrl: /auth/token
+          scopes: {}

--- a/openapi/karman.yaml
+++ b/openapi/karman.yaml
@@ -50,7 +50,7 @@ paths: {}
 x-tagGroups:
   - name: Library Management
     tags:
+      - auth
       - song
       - media
       - upload
-# TODO: ETag support (and If-None-Match, If-Modified-Since)

--- a/openapi/karman.yaml
+++ b/openapi/karman.yaml
@@ -54,3 +54,4 @@ x-tagGroups:
       - song
       - media
       - upload
+      - user

--- a/openapi/karman.yaml
+++ b/openapi/karman.yaml
@@ -46,7 +46,11 @@ info:
   license:
     name: MIT
     url: https://opensource.org/license/mit/
+
+
 paths: {}
+
+
 x-tagGroups:
   - name: Library Management
     tags:
@@ -55,3 +59,30 @@ x-tagGroups:
       - media
       - upload
       - user
+
+
+security:
+  - OAuth2: []
+
+
+components:
+  securitySchemes:
+    OAuth2:
+      type: oauth2
+      description: |-
+        In order to access this endpoint you must provide a valid `Bearer` token
+        in the `Authorization` header.
+        
+        See the [`/auth/token`](#tag/auth/operation/createToken) endpoint for more information on how to acquire a token.
+      flows:
+        # noinspection YAMLSchemaValidation
+        urn:ietf:params:oauth:grant-type:token-exchange: {}
+          # Semantically these should be uncommented.
+          # However, visually Redoc only shows the refreshUrl which might be misleading.
+          # The urls from the password flow display in a way that it can also be applied to this flow.
+
+          # tokenUrl: /auth/token
+          # refreshUrl: /auth/token
+        password:
+          tokenUrl: /auth/token
+          refreshUrl: /auth/token

--- a/openapi/tags/auth.yaml
+++ b/openapi/tags/auth.yaml
@@ -5,47 +5,46 @@ info:
   license:
     name: MIT
     url: https://opensource.org/license/mit/
+
+
 tags:
   - name: auth
     x-displayName: Authentication
     description: |-
       The Karman API uses token-based authentication.
       Most endpoints are protected and can only be accessed if a valid `Bearer` token is provided in the `Authorization` header.
-      Although these endpoints are intentionally similar to OAuth 2, the Karman API currently does not support OAuth.
-      There is currently no support for OAuth scopes but to preserve compatibility with OAuth libraries
-      this endpoint still accepts a `scope` parameter (and ignores it).
+      Acquiring a token is done through OAuth 2.
       
-      Clients should treat tokens as opaque strings.
-      Even though specific known token formats may be used (such as JWT), the token format is not defined and may change at any time.
-      To preserve compatibility with OAuth libraries this endpoint also returns a `scope` for the token.
-      However, its value is meaningless.
+      Technically Karman currently supports only a limited subset of the OAuth specification.
+      In particular:
+      
+      - Only a limited set of flows is supported. The Authorization Code flow is not supported.
+      - OAuth `scopes` are currently not supported.
+      - Client Authentication is currently not supported.
+
+
 paths:
   /auth/token:
     post:
       operationId: createToken
       summary: Acquire an Access Token
       tags: [ auth ]
+      security: []
       description: |-
         This is the *login* endpoint of the Karman API.
         The login involves exchanging known credentials for a Karman API Token.
         Known credentials can be usernames and passwords but could also for example be an id token for an OIDC provider.
-        There are multiple possible token exchanges, that loosely correspond to OAuth 2 flows.
-        Each token exchange has different requirements for the parameters in the request body.
-        See the request schema below for details.
+        This endpoint implements the OAuth 2 token endpoint but only supports a limited number of flows.
         
         The response to a valid request contains an access token that can be used to authenticate request to the Karman API.
         Depending on the exchange mechanism used, the response may also contain a refresh token.
-        
-        **Attention**: The error response format for this endpoint does not conform to
-        [RFC 9457](https://datatracker.ietf.org/doc/html/rfc9457) in order to be compatible with the OAuth 2 spec.
       requestBody:
         required: true
         description: |-
           The request body contains authentication information.
           Depending on the `grant_type` different fields may be required or supported.
-          This request schema aims to be compatible with the OAuth token endpoint.
-          Note however, that the Karman API does not currently implement OAuth,
-          but similarity to the OAuth specification may mean that you can use OAuth libraries to work with this endpoint.
+          The request schema corresponds to the OAuth 2 spec, however not all features are supported.
+          In particular the `scope` field is not supported and will be ignored.
           
           Only the `grant_type`s documented below are supported.
           In particular the `authorization_code` and `client_credentials` grants are **not** currently supported.
@@ -67,6 +66,7 @@ paths:
         400: { $ref: "#/components/responses/TokenError" }
         5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
 
+
 components:
   schemas:
     UsernamePassword:
@@ -78,7 +78,7 @@ components:
           type: string
           enum: [ password ]
           description: |-
-            The `password` grant type indicates that you are requesting a username/password based token exchange.
+            The `password` grant type indicates that you want to exchange a username/password pair for a Karman token.
             This is the simplest way to acquire a token for the Karman API.
             In most cases the user must exist in a local or remote user storage on the server before this grant type can succeed.
         username:
@@ -93,6 +93,7 @@ components:
           example: "hunter2"
           description: |-
             The password of the user.
+
     RefreshToken:
       type: object
       title: Refresh Token
@@ -109,6 +110,7 @@ components:
           example: "2YotnFZFEjr1zCsicMWpAA"
           description: |-
             A valid refresh token, previously issued by the Karman API.
+
     TokenExchange:
       type: object
       title: Token Exchange
@@ -140,6 +142,7 @@ components:
             Identifies the type of the `subject_token`.
             Usually only a single value is valid for a single third party service provider.
             Currently only OIDC ID tokens are supported.
+
   responses:
     TokenResponse:
       x-summary: "OK"
@@ -176,6 +179,7 @@ components:
                   In some cases a refresh token can be issued.
                   Not all grant types will issue a refresh token.
                   The token can be used to acquire a new access token (using the `refresh_token` grant type) before it expires.
+
     TokenError:
       x-summary: Bad Request
       description: |-

--- a/openapi/tags/auth.yaml
+++ b/openapi/tags/auth.yaml
@@ -1,0 +1,217 @@
+openapi: 3.0.3
+info:
+  title: Karman Authentication
+  version: v1
+  license:
+    name: MIT
+    url: https://opensource.org/license/mit/
+tags:
+  - name: auth
+    x-displayName: Authentication
+    description: |-
+      The Karman API uses token-based authentication.
+      Most endpoints are protected and can only be accessed if a valid `Bearer` token is provided in the `Authorization` header.
+      Although these endpoints are intentionally similar to OAuth 2, the Karman API currently does not support OAuth.
+      There is currently no support for OAuth scopes but to preserve compatibility with OAuth libraries
+      this endpoint still accepts a `scope` parameter (and ignores it).
+      
+      Clients should treat tokens as opaque strings.
+      Even though specific known token formats may be used (such as JWT), the token format is not defined and may change at any time.
+      To preserve compatibility with OAuth libraries this endpoint also returns a `scope` for the token.
+      However, its value is meaningless.
+paths:
+  /auth/token:
+    post:
+      operationId: createToken
+      summary: Acquire an Access Token
+      tags: [ auth ]
+      description: |-
+        This is the *login* endpoint of the Karman API.
+        The login involves exchanging known credentials for a Karman API Token.
+        Known credentials can be usernames and passwords but could also for example be an id token for an OIDC provider.
+        There are multiple possible token exchanges, that loosely correspond to OAuth 2 flows.
+        Each token exchange has different requirements for the parameters in the request body.
+        See the request schema below for details.
+        
+        The response to a valid request contains an access token that can be used to authenticate request to the Karman API.
+        Depending on the exchange mechanism used, the response may also contain a refresh token.
+        
+        **Attention**: The error response format for this endpoint does not conform to
+        [RFC 9457](https://datatracker.ietf.org/doc/html/rfc9457) in order to be compatible with the OAuth 2 spec.
+      requestBody:
+        required: true
+        description: |-
+          The request body contains authentication information.
+          Depending on the `grant_type` different fields may be required or supported.
+          This request schema aims to be compatible with the OAuth token endpoint.
+          Note however, that the Karman API does not currently implement OAuth,
+          but similarity to the OAuth specification may mean that you can use OAuth libraries to work with this endpoint.
+          
+          Only the `grant_type`s documented below are supported.
+          In particular the `authorization_code` and `client_credentials` grants are **not** currently supported.
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              discriminator:
+                propertyName: grant_type
+                mapping:
+                  password: "#/components/schemas/UsernamePassword"
+                  refresh_token: "#/components/schemas/RefreshToken"
+                  urn:ietf:params:oauth:grant-type:token-exchange: "#/components/schemas/TokenExchange"
+              oneOf:
+                - $ref: "#/components/schemas/UsernamePassword"
+                - $ref: "#/components/schemas/RefreshToken"
+                - $ref: "#/components/schemas/TokenExchange"
+      responses:
+        200: { $ref: "#/components/responses/TokenResponse" }
+        400: { $ref: "#/components/responses/TokenError" }
+        5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+
+components:
+  schemas:
+    UsernamePassword:
+      type: object
+      title: Username & Password
+      required: [ grant_type, username, password ]
+      properties:
+        grant_type:
+          type: string
+          enum: [ password ]
+          description: |-
+            The `password` grant type indicates that you are requesting a username/password based token exchange.
+            This is the simplest way to acquire a token for the Karman API.
+            In most cases the user must exist in a local or remote user storage on the server before this grant type can succeed.
+        username:
+          type: string
+          minLength: 3
+          example: "mario"
+          description: |-
+            The unique username identifying the user trying to sing in.
+            The Karman API does not make restrictions on the username format.
+        password:
+          type: string
+          example: "hunter2"
+          description: |-
+            The password of the user.
+    RefreshToken:
+      type: object
+      title: Refresh Token
+      required: [ grant_type, refresh_token ]
+      properties:
+        grant_type:
+          type: string
+          enum: [ refresh_token ]
+          description: |-
+            The `refresh_token` grant type acquires a new access token using a previously issued refresh token.
+            The refresh token must have been issued by the Karman API and must not be expired.
+        refresh_token:
+          type: string
+          example: "2YotnFZFEjr1zCsicMWpAA"
+          description: |-
+            A valid refresh token, previously issued by the Karman API.
+    TokenExchange:
+      type: object
+      title: Token Exchange
+      required: [ grant_type, subject_token, subject_token_type ]
+      properties:
+        grant_type:
+          type: string
+          enum: [ urn:ietf:params:oauth:grant-type:token-exchange ]
+          description: |-
+            The token exchange grant type allows you to exchange a token from an external service for a Karman API token.
+            Through this mechanism you can implement SSO or social logins.
+            Use the value `urn:ietf:params:oauth:grant-type:token-exchange` for this grant type.
+            
+            Depending on the server settings, users may be created on-the-fly when using this grant type,
+            using data encoded in the provided token.
+            
+            The set of acceptable tokens depends on the server settings.
+        subject_token:
+          type: string
+          description: |-
+            The token of a third party service that should be exchanged for a Karman API token.
+            In most cases this would be an ID token of an OIDC provider but other token types may be supported as well.
+            The token must be valid and not expired.
+          example: "2YotnFZFEjr1zCsicMWpAA"
+        subject_token_type:
+          type: string
+          enum: [ urn:ietf:params:oauth:token-type:id_token ]
+          description: |-
+            Identifies the type of the `subject_token`.
+            Usually only a single value is valid for a single third party service provider.
+            Currently only OIDC ID tokens are supported.
+  responses:
+    TokenResponse:
+      x-summary: "OK"
+      description: |-
+        A token response contains the access token for the Karman API as well as information about the token's validity.
+      content:
+        application/json:
+          schema:
+            title: Token Response
+            type: object
+            required: [ access_token, token_type, expires_in ]
+            properties:
+              access_token:
+                type: string
+                example: "5ad5f22dd7c905198befcc3bbe56ee1afd4bbc71"
+                description: |-
+                  The access token.
+                  This token can be used to authenticate subsequent requests to the Karman API.
+              token_type:
+                type: string
+                enum: [ "Bearer" ]
+                description: |-
+                  The token type is always `Bearer`.
+              expires_in:
+                type: integer
+                example: 600
+                description: |-
+                  The number of seconds the access token is valid.
+                  If a `refresh_token` is present, you should refresh the access token shortly before it expires.
+              refresh_token:
+                type: string
+                example: "cb0f673acf5cdb2bd30b9d86ae3ffd87b5524d54"
+                description: |-
+                  In some cases a refresh token can be issued.
+                  Not all grant types will issue a refresh token.
+                  The token can be used to acquire a new access token (using the `refresh_token` grant type) before it expires.
+    TokenError:
+      x-summary: Bad Request
+      description: |-
+        This response indicates that the request was not successful because it was not formatted correctly
+        or because the server refused to accept the provided credentials.
+      content:
+        application/json:
+          schema:
+            title: Token Error
+            type: object
+            required: [ error ]
+            properties:
+              error:
+                type: string
+                enum: [ invalid_request, invalid_client, invalid_grant, unauthorized_client, unsupported_grant_type, invalid_scope, invalid_dpop_proof ]
+                example: "invalid_grant"
+                description: |-
+                  The type of error that occurred:
+                  
+                  - `invalid_request`: This error indicates that the request was incorrectly formatted, e.g. a required field was missing.
+                  - `invalid_client`: Not used by the Karman API.
+                  - `invalid_grant`: The provided credentials are invalid (for example the username and password did not match).
+                  - `unauthorized_client`: Not used by the Karman API.
+                  - `unsupported_grant_type`: The requested `grant_type` is not supported or has been disabled.
+                  - `invalid_scope`: Not used by the Karman API.
+                  - `invalid_dpop_proof`: Not used by the Karman API.
+              error_description:
+                type: string
+                example: "invalid username or password"
+                description: |-
+                  A description of the error.
+                  This value is intended for developers and should **not** be displayed to end users.
+              error_uri:
+                type: string
+                example: "https://example.com/more-infos"
+                format: uri
+                description: |-
+                  A URI where more information about this error is available.
+                  If present for the `invalid_grant` error, this may be presented as a link to the user.

--- a/openapi/tags/auth.yaml
+++ b/openapi/tags/auth.yaml
@@ -77,19 +77,22 @@ components:
         grant_type:
           type: string
           enum: [ password ]
+          minLength: 1
+          example: "password"
           description: |-
             The `password` grant type indicates that you want to exchange a username/password pair for a Karman token.
             This is the simplest way to acquire a token for the Karman API.
             In most cases the user must exist in a local or remote user storage on the server before this grant type can succeed.
         username:
           type: string
-          minLength: 3
+          minLength: 1
           example: "mario"
           description: |-
             The unique username identifying the user trying to sing in.
             The Karman API does not make restrictions on the username format.
         password:
           type: string
+          minLength: 1
           example: "hunter2"
           description: |-
             The password of the user.
@@ -102,11 +105,14 @@ components:
         grant_type:
           type: string
           enum: [ refresh_token ]
+          minLength: 1
+          example: "refresh_token"
           description: |-
             The `refresh_token` grant type acquires a new access token using a previously issued refresh token.
             The refresh token must have been issued by the Karman API and must not be expired.
         refresh_token:
           type: string
+          minLength: 1
           example: "2YotnFZFEjr1zCsicMWpAA"
           description: |-
             A valid refresh token, previously issued by the Karman API.
@@ -119,6 +125,8 @@ components:
         grant_type:
           type: string
           enum: [ urn:ietf:params:oauth:grant-type:token-exchange ]
+          minLength: 1
+          example: "urn:ietf:params:oauth:grant-type:token-exchange"
           description: |-
             The token exchange grant type allows you to exchange a token from an external service for a Karman API token.
             Through this mechanism you can implement SSO or social logins.
@@ -130,6 +138,7 @@ components:
             The set of acceptable tokens depends on the server settings.
         subject_token:
           type: string
+          minLength: 1
           description: |-
             The token of a third party service that should be exchanged for a Karman API token.
             In most cases this would be an ID token of an OIDC provider but other token types may be supported as well.
@@ -138,6 +147,8 @@ components:
         subject_token_type:
           type: string
           enum: [ urn:ietf:params:oauth:token-type:id_token ]
+          minLength: 1
+          example: "urn:ietf:params:oauth:token-type:id_token"
           description: |-
             Identifies the type of the `subject_token`.
             Usually only a single value is valid for a single third party service provider.
@@ -157,6 +168,7 @@ components:
             properties:
               access_token:
                 type: string
+                minLength: 1
                 example: "5ad5f22dd7c905198befcc3bbe56ee1afd4bbc71"
                 description: |-
                   The access token.
@@ -164,6 +176,8 @@ components:
               token_type:
                 type: string
                 enum: [ "Bearer" ]
+                minLength: 1
+                example: "Bearer"
                 description: |-
                   The token type is always `Bearer`.
               expires_in:
@@ -175,6 +189,7 @@ components:
               refresh_token:
                 type: string
                 example: "cb0f673acf5cdb2bd30b9d86ae3ffd87b5524d54"
+                minLength: 1
                 description: |-
                   In some cases a refresh token can be issued.
                   Not all grant types will issue a refresh token.
@@ -195,6 +210,7 @@ components:
               error:
                 type: string
                 enum: [ invalid_request, invalid_client, invalid_grant, unauthorized_client, unsupported_grant_type, invalid_scope, invalid_dpop_proof ]
+                minLength: 1
                 example: "invalid_grant"
                 description: |-
                   The type of error that occurred:

--- a/openapi/tags/media.yaml
+++ b/openapi/tags/media.yaml
@@ -5,6 +5,8 @@ info:
   license:
     name: MIT
     url: https://opensource.org/license/mit/
+
+
 tags:
   - name: media
     x-displayName: Managing Song Media
@@ -18,14 +20,20 @@ tags:
       - A background image
       
       UltraStar enforces the presence of an audio file for valid songs, but the Karman API does not.
+      
+
 paths:
   /v1/songs/{uuid}/cover:
     parameters:
       - $ref: "songs.yaml#/components/parameters/songUUID"
+
     get:
       operationId: getSongCover
       summary: Get the Cover of a Song
       tags: [ media ]
+      security:
+        - {}
+        - OAuth2: []
       description: |-
         Fetch the cover image of a song.
         
@@ -34,8 +42,11 @@ paths:
         200: { $ref: "#/components/responses/Media" }
         3XX: { $ref: "#/components/responses/Redirect" }
         400: { $ref: "../common/problem-details.yaml#/components/responses/InvalidUUID" }
+        401: { $ref: "../common/problem-details.yaml#/components/responses/Unauthorized" }
+        403: { $ref: "../common/problem-details.yaml#/components/responses/PermissionDenied" }
         404: { $ref: "#/components/responses/NotFound" }
         5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+
     put:
       operationId: replaceSongCover
       summary: Replace the Cover of a Song
@@ -64,10 +75,13 @@ paths:
       responses:
         204: { description: Success }
         400: { $ref: "../common/problem-details.yaml#/components/responses/InvalidUUID" }
+        401: { $ref: "../common/problem-details.yaml#/components/responses/Unauthorized" }
+        403: { $ref: "../common/problem-details.yaml#/components/responses/PermissionDenied" }
         404: { $ref: "songs.yaml#/components/responses/SongNotFound" }
         409: { $ref: "songs.yaml#/components/responses/UploadSongCannotBeModified" }
         415: { $ref: "../common/problem-details.yaml#/components/responses/UnsupportedMediaType" }
         5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+
     delete:
       operationId: deleteSongCover
       summary: Delete the Cover of a Song
@@ -78,15 +92,23 @@ paths:
       responses:
         204: { description: Success }
         400: { $ref: "../common/problem-details.yaml#/components/responses/InvalidUUID" }
+        401: { $ref: "../common/problem-details.yaml#/components/responses/Unauthorized" }
+        403: { $ref: "../common/problem-details.yaml#/components/responses/PermissionDenied" }
         404: { $ref: "songs.yaml#/components/responses/SongNotFound" }
         5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+
+
   /v1/songs/{uuid}/background:
     parameters:
       - $ref: "songs.yaml#/components/parameters/songUUID"
+
     get:
       operationId: getSongBackground
       summary: Get the Background Image of a Song
       tags: [ media ]
+      security:
+        - {}
+        - OAuth2: []
       description: |-
         Fetch the background image of the song with the specified `uuid`.
         
@@ -95,8 +117,11 @@ paths:
         200: { $ref: "#/components/responses/Media" }
         3XX: { $ref: "#/components/responses/Redirect" }
         400: { $ref: "../common/problem-details.yaml#/components/responses/InvalidUUID" }
+        401: { $ref: "../common/problem-details.yaml#/components/responses/Unauthorized" }
+        403: { $ref: "../common/problem-details.yaml#/components/responses/PermissionDenied" }
         404: { $ref: "#/components/responses/NotFound" }
         5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+
     put:
       operationId: replaceSongBackground
       summary: Replace the Background Image of a Song
@@ -125,10 +150,13 @@ paths:
       responses:
         204: { description: Success }
         400: { $ref: "../common/problem-details.yaml#/components/responses/InvalidUUID" }
+        401: { $ref: "../common/problem-details.yaml#/components/responses/Unauthorized" }
+        403: { $ref: "../common/problem-details.yaml#/components/responses/PermissionDenied" }
         404: { $ref: "songs.yaml#/components/responses/SongNotFound" }
         409: { $ref: "songs.yaml#/components/responses/UploadSongCannotBeModified" }
         415: { $ref: "../common/problem-details.yaml#/components/responses/UnsupportedMediaType" }
         5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+
     delete:
       operationId: deleteSongBackground
       summary: Delete the Background Image of a Song
@@ -139,11 +167,16 @@ paths:
       responses:
         204: { description: Success }
         400: { $ref: "../common/problem-details.yaml#/components/responses/InvalidUUID" }
+        401: { $ref: "../common/problem-details.yaml#/components/responses/Unauthorized" }
+        403: { $ref: "../common/problem-details.yaml#/components/responses/PermissionDenied" }
         404: { $ref: "songs.yaml#/components/responses/SongNotFound" }
         5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+
+
   /v1/songs/{uuid}/video:
     parameters:
       - $ref: "songs.yaml#/components/parameters/songUUID"
+
     get:
       operationId: getSongVideo
       summary: Get the Video of a Song
@@ -156,8 +189,11 @@ paths:
         200: { $ref: "#/components/responses/Media" }
         3XX: { $ref: "#/components/responses/Redirect" }
         400: { $ref: "../common/problem-details.yaml#/components/responses/InvalidUUID" }
+        401: { $ref: "../common/problem-details.yaml#/components/responses/Unauthorized" }
+        403: { $ref: "../common/problem-details.yaml#/components/responses/PermissionDenied" }
         404: { $ref: "#/components/responses/NotFound" }
         5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+
     put:
       operationId: replaceSongVideo
       summary: Replace the Video of a Song
@@ -186,10 +222,13 @@ paths:
       responses:
         204: { description: Success }
         400: { $ref: "../common/problem-details.yaml#/components/responses/InvalidUUID" }
+        401: { $ref: "../common/problem-details.yaml#/components/responses/Unauthorized" }
+        403: { $ref: "../common/problem-details.yaml#/components/responses/PermissionDenied" }
         404: { $ref: "songs.yaml#/components/responses/SongNotFound" }
         409: { $ref: "songs.yaml#/components/responses/UploadSongCannotBeModified" }
         415: { $ref: "../common/problem-details.yaml#/components/responses/UnsupportedMediaType" }
         5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+
     delete:
       operationId: deleteSongVideo
       summary: Delete the Video of a Song
@@ -200,11 +239,16 @@ paths:
       responses:
         204: { description: Success }
         400: { $ref: "../common/problem-details.yaml#/components/responses/InvalidUUID" }
+        401: { $ref: "../common/problem-details.yaml#/components/responses/Unauthorized" }
+        403: { $ref: "../common/problem-details.yaml#/components/responses/PermissionDenied" }
         404: { $ref: "songs.yaml#/components/responses/SongNotFound" }
         5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+
+
   /v1/songs/{uuid}/audio:
     parameters:
       - $ref: "songs.yaml#/components/parameters/songUUID"
+
     get:
       operationId: getSongAudio
       summary: Get the Audio of a Song
@@ -217,8 +261,11 @@ paths:
         200: { $ref: "#/components/responses/Media" }
         3XX: { $ref: "#/components/responses/Redirect" }
         400: { $ref: "../common/problem-details.yaml#/components/responses/InvalidUUID" }
+        401: { $ref: "../common/problem-details.yaml#/components/responses/Unauthorized" }
+        403: { $ref: "../common/problem-details.yaml#/components/responses/PermissionDenied" }
         404: { $ref: "#/components/responses/NotFound" }
         5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+
     put:
       operationId: replaceSongAudio
       summary: Replace the Audio of a Song
@@ -247,10 +294,13 @@ paths:
       responses:
         204: { description: Success }
         400: { $ref: "../common/problem-details.yaml#/components/responses/InvalidUUID" }
+        401: { $ref: "../common/problem-details.yaml#/components/responses/Unauthorized" }
+        403: { $ref: "../common/problem-details.yaml#/components/responses/PermissionDenied" }
         404: { $ref: "songs.yaml#/components/responses/SongNotFound" }
         409: { $ref: "songs.yaml#/components/responses/UploadSongCannotBeModified" }
         415: { $ref: "../common/problem-details.yaml#/components/responses/UnsupportedMediaType" }
         5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+
     delete:
       operationId: deleteSongAudio
       summary: Delete the Audio of a Song
@@ -261,8 +311,12 @@ paths:
       responses:
         204: { description: Success }
         400: { $ref: "../common/problem-details.yaml#/components/responses/InvalidUUID" }
+        401: { $ref: "../common/problem-details.yaml#/components/responses/Unauthorized" }
+        403: { $ref: "../common/problem-details.yaml#/components/responses/PermissionDenied" }
         404: { $ref: "songs.yaml#/components/responses/SongNotFound" }
         5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+
+
 components:
   schemas:
     FileNotFoundError:
@@ -291,6 +345,8 @@ components:
               enum: [ cover, background, audio, video ]
               description: |-
                 The kind of media that was not found.
+                
+
   responses:
     NotFound:
       x-summary: Not Found
@@ -302,6 +358,7 @@ components:
             oneOf:
               - $ref: "songs.yaml#/components/schemas/SongNotFoundError"
               - $ref: "#/components/schemas/FileNotFoundError"
+
     Media:
       description: Success
       headers:
@@ -327,6 +384,7 @@ components:
             description: "The binary data of the image."
             type: string
             format: binary
+
     Redirect:
       x-summary: Redirect
       description: |-

--- a/openapi/tags/songs.yaml
+++ b/openapi/tags/songs.yaml
@@ -5,6 +5,8 @@ info:
   license:
     name: MIT
     url: https://opensource.org/license/mit/
+
+
 tags:
   - name: song
     x-displayName: Managing Songs
@@ -92,6 +94,8 @@ tags:
       - `has:audio`: Filters songs with audio
       - `has:video`: Filters songs with video
       - `has:background`: Filters songs with background
+      
+
 paths:
   /v1/songs:
     post:
@@ -135,11 +139,17 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/InvalidTXTError"
+        401: { $ref: "../common/problem-details.yaml#/components/responses/Unauthorized" }
+        403: { $ref: "../common/problem-details.yaml#/components/responses/PermissionDenied" }
         5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+
     get:
       operationId: findSongs
       summary: Find Songs
       tags: [ song ]
+      security:
+        - {}
+        - OAuth2: []
       parameters:
         - $ref: "#/components/parameters/query"
         - $ref: "../common/pagination.yaml#/components/parameters/limit"
@@ -166,14 +176,21 @@ paths:
                   An array of `Song` resources.
                 items:
                   $ref: '#/components/schemas/Song'
+        401: { $ref: "../common/problem-details.yaml#/components/responses/Unauthorized" }
         5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+
+
   /v1/songs/{uuid}:
     parameters:
       - $ref: "#/components/parameters/songUUID"
+
     get:
       operationId: getSong
       summary: Get Song by UUID
       tags: [ song ]
+      security:
+        - {}
+        - OAuth2: []
       description: |-
         Fetches a song by the specified `uuid`.
       responses:
@@ -185,8 +202,11 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/Song' }
         400: { $ref: "../common/problem-details.yaml#/components/responses/InvalidUUID" }
+        401: { $ref: "../common/problem-details.yaml#/components/responses/Unauthorized" }
+        403: { $ref: "../common/problem-details.yaml#/components/responses/PermissionDenied" }
         404: { $ref: "#/components/responses/SongNotFound" }
         5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+
     patch:
       operationId: updateSong
       summary: |-
@@ -228,10 +248,13 @@ paths:
             The song was updated successfully.
             Future `GET /v1/songs/{uuid}` requests will reflect the changes.
         400: { $ref: "../common/problem-details.yaml#/components/responses/BadRequestOrInvalidUUID" }
+        401: { $ref: "../common/problem-details.yaml#/components/responses/Unauthorized" }
+        403: { $ref: "../common/problem-details.yaml#/components/responses/PermissionDenied" }
         404: { $ref: "#/components/responses/SongNotFound" }
         409: { $ref: "#/components/responses/UploadSongCannotBeModified" }
         422: { $ref: "../common/problem-details.yaml#/components/responses/UnprocessableEntity" }
         5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+
     delete:
       operationId: deleteSong
       summary: Delete Song by UUID
@@ -242,14 +265,22 @@ paths:
       responses:
         204: { description: Success }
         400: { $ref: "../common/problem-details.yaml#/components/responses/InvalidUUID" }
+        401: { $ref: "../common/problem-details.yaml#/components/responses/Unauthorized" }
+        403: { $ref: "../common/problem-details.yaml#/components/responses/PermissionDenied" }
         5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+
+
   /v1/songs/{uuid}/txt:
     parameters:
       - $ref: "#/components/parameters/songUUID"
+
     get:
       operationId: getSongTxt
       summary: Generate a TXT file
       tags: [ song ]
+      security:
+        - {}
+        - OAuth2: []
       description: |-
         Generate a representation of the song identified by `uuid` in the UltraStar TXT format.
         The resulting TXT will include metadata tags as well as the karaoke data.
@@ -291,8 +322,11 @@ paths:
                 ...
                 E
         400: { $ref: "../common/problem-details.yaml#/components/responses/InvalidUUID" }
+        401: { $ref: "../common/problem-details.yaml#/components/responses/Unauthorized" }
+        403: { $ref: "../common/problem-details.yaml#/components/responses/PermissionDenied" }
         404: { $ref: "#/components/responses/SongNotFound" }
         5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+
     put:
       operationId: replaceSongTxt
       summary: Replace Song with TXT
@@ -339,12 +373,17 @@ paths:
                 oneOf:
                   - $ref: "../common/problem-details.yaml#/components/schemas/InvalidUUIDError"
                   - $ref: "#/components/schemas/InvalidTXTError"
+        401: { $ref: "../common/problem-details.yaml#/components/responses/Unauthorized" }
+        403: { $ref: "../common/problem-details.yaml#/components/responses/PermissionDenied" }
         404: { $ref: "#/components/responses/SongNotFound" }
         409: { $ref: "#/components/responses/UploadSongCannotBeModified" }
         5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+
+
   /v1/songs/{uuid}/archive:
     parameters:
       - $ref: "#/components/parameters/songUUID"
+
     get:
       operationId: getSongArchive
       summary: |-
@@ -372,6 +411,8 @@ paths:
                 type: string
                 format: binary
         400: { $ref: "../common/problem-details.yaml#/components/responses/InvalidUUID" }
+        401: { $ref: "../common/problem-details.yaml#/components/responses/Unauthorized" }
+        403: { $ref: "../common/problem-details.yaml#/components/responses/PermissionDenied" }
         404: { $ref: "#/components/responses/SongNotFound" }
         406:
           x-summary: Not Acceptable
@@ -387,6 +428,8 @@ paths:
                 allOf:
                   - $ref: "../common/problem-details.yaml#/components/schemas/ProblemDetails"
         5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+
+
 components:
   parameters:
     query:
@@ -399,6 +442,7 @@ components:
       description: |-
         A query used for filtering and searching results.
         The syntax and semantics are described in [Search Queries](#tag/song/Search-Queries).
+
     songUUID:
       in: path
       name: uuid
@@ -411,6 +455,8 @@ components:
       example: "A37FCD49-40A2-4FB4-83AA-49A57B62317F"
       description: |-
         The UUID of the song to operate on.
+        
+
   schemas:
     Song:
       type: object
@@ -671,6 +717,7 @@ components:
               example: 1080
               description: |-
                 The height of the image in **pixels**.
+
     AutoMedley:
       type: object
       title: Auto
@@ -679,6 +726,7 @@ components:
           enum: [ auto ]
           description: |-
             `auto` medley mode enables automatic calculation of medleys by UltraStar. This is the default.
+
     ManualMedley:
       type: object
       title: Manual
@@ -702,6 +750,7 @@ components:
             The **beat** at which the medley should end.
 
             This corresponds to the UltraStar `#MEDLEYENDBEAT` tag.
+
     OffMedley:
       type: object
       title: Off
@@ -710,6 +759,7 @@ components:
           enum: [ off ]
           description: |-
             `off` mode disables medley calculation completely. No medley will be available.
+
     SongNotFoundError:
       title: Song Not Found
       example:
@@ -730,6 +780,7 @@ components:
               example: "F0481266-E081-4E28-BB20-4D6221C90C2F"
               description: |-
                 The requested UUID for which no song was found.
+
     InvalidTXTError:
       title: Invalid TXT
       example:
@@ -748,6 +799,8 @@ components:
               description: |-
                 The line of the input on which the error occurred.
               example: 73
+
+
   responses:
     SongNotFound:
       x-summary: Not Found
@@ -757,6 +810,7 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/SongNotFoundError"
+
     UploadSongCannotBeModified:
       x-summary: "Conflict"
       description: |-

--- a/openapi/tags/songs.yaml
+++ b/openapi/tags/songs.yaml
@@ -141,12 +141,11 @@ paths:
       summary: Find Songs
       tags: [ song ]
       parameters:
+        - $ref: "#/components/parameters/query"
         - $ref: "../common/pagination.yaml#/components/parameters/limit"
         - $ref: "../common/pagination.yaml#/components/parameters/offset"
-        - $ref: "#/components/parameters/query"
       description: |-
         List all songs in the database.
-      # TODO: Add filter and sort options
       responses:
         200:
           x-summary: Success
@@ -404,7 +403,6 @@ components:
       in: path
       name: uuid
       required: true
-      allowReserved: true
       schema:
         type: string
         format: uuid

--- a/openapi/tags/songs.yaml
+++ b/openapi/tags/songs.yaml
@@ -675,6 +675,7 @@ components:
                 The height of the image in **pixels**.
     AutoMedley:
       type: object
+      title: Auto
       properties:
         mode:
           enum: [ auto ]
@@ -682,6 +683,7 @@ components:
             `auto` medley mode enables automatic calculation of medleys by UltraStar. This is the default.
     ManualMedley:
       type: object
+      title: Manual
       required: [ medleyStartBeat, medleyEndBeat ]
       properties:
         mode:
@@ -704,6 +706,7 @@ components:
             This corresponds to the UltraStar `#MEDLEYENDBEAT` tag.
     OffMedley:
       type: object
+      title: Off
       properties:
         mode:
           enum: [ off ]

--- a/openapi/tags/uploads.yaml
+++ b/openapi/tags/uploads.yaml
@@ -82,7 +82,7 @@ paths:
               example:
                 uuid: "205F5B79-9B05-4D54-B5A1-4943894E7501"
                 status: "open"
-              schema: { $ref: '#/components/schemas/Upload' }
+              schema: { $ref: '#/components/schemas/OpenUpload' }
         401: { $ref: "../common/problem-details.yaml#/components/responses/Unauthorized" }
         403: { $ref: "../common/problem-details.yaml#/components/responses/PermissionDenied" }
         5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
@@ -277,9 +277,10 @@ paths:
           content:
             application/json:
               example:
+                uuid: "4FED7DDD-778E-4C9E-B9BD-15D767825ACA"
                 status: pending
               schema:
-                $ref: '#/components/schemas/Upload'
+                $ref: '#/components/schemas/PendingUpload'
         400: { $ref: "../common/problem-details.yaml#/components/responses/InvalidUUID" }
         401: { $ref: "../common/problem-details.yaml#/components/responses/Unauthorized" }
         403: { $ref: "../common/problem-details.yaml#/components/responses/PermissionDenied" }
@@ -308,11 +309,12 @@ paths:
           content:
             application/json:
               example:
+                uuid: "4FED7DDD-778E-4C9E-B9BD-15D767825ACA"
                 status: processing
                 songsTotal: -1
                 songsProcessed: 0
               schema:
-                $ref: '#/components/schemas/Upload'
+                $ref: '#/components/schemas/ProcessingUpload'
         400: { $ref: "../common/problem-details.yaml#/components/responses/InvalidUUID" }
         401: { $ref: "../common/problem-details.yaml#/components/responses/Unauthorized" }
         403: { $ref: "../common/problem-details.yaml#/components/responses/PermissionDenied" }
@@ -462,6 +464,7 @@ components:
         - $ref: "#/components/schemas/PendingUpload"
         - $ref: "#/components/schemas/ProcessingUpload"
         - $ref: "#/components/schemas/DoneUpload"
+
     OpenUpload:
       type: object
       required: [ uuid, status ]
@@ -469,11 +472,16 @@ components:
         uuid:
           type: string
           format: uuid
+          minLength: 36
+          maxLength: 36
           example: "205F5B79-9B05-4D54-B5A1-4943894E7501"
           description: |-
             The UUID of the upload.
         status:
           enum: [ "open" ]
+          type: string
+          minLength: 1
+          example: "open"
           description: |-
             The `open` status indicates that the upload accepts file uploads and deletes.
             An upload in this status will not be processed automatically.
@@ -485,11 +493,16 @@ components:
         uuid:
           type: string
           format: uuid
+          minLength: 36
+          maxLength: 36
           example: "205F5B79-9B05-4D54-B5A1-4943894E7501"
           description: |-
             The UUID of the upload.
         status:
           enum: [ "pending" ]
+          type: string
+          minLength: 1
+          example: "pending"
           description: |-
             The `pending` status indicates that the upload has been marked for processing but processing has not started yet.
             An upload in this status will not accept file uploads.
@@ -501,11 +514,16 @@ components:
         uuid:
           type: string
           format: uuid
+          minLength: 36
+          maxLength: 36
           example: "205F5B79-9B05-4D54-B5A1-4943894E7501"
           description: |-
             The UUID of the upload.
         status:
           enum: [ "processing" ]
+          type: string
+          minLength: 1
+          example: "processing"
           description: |-
             The `processing` status indicates that an upload is currently being processed.
             The response contains additional fields indicating the progress of the processing.
@@ -539,11 +557,16 @@ components:
         uuid:
           type: string
           format: uuid
+          minLength: 36
+          maxLength: 36
           example: "205F5B79-9B05-4D54-B5A1-4943894E7501"
           description: |-
             The UUID of the upload.
         status:
+          type: string
+          minLength: 1
           enum: [ "done" ]
+          example: "done"
           description: |-
             The `done` status indicates that the upload has been analyzed and it is now possible to import songs.
         songsTotal:
@@ -564,11 +587,13 @@ components:
       properties:
         file:
           type: string
+          minLength: 1
           example: "folder/file.txt"
           description: |-
             The file that caused the error, relative to the root of the upload.
         message:
           type: string
+          minLength: 1
           example: "could not parse"
           description: |-
             A message describing the cause of the error.
@@ -616,6 +641,7 @@ components:
           items: { $ref: '#/components/schemas/File' }
         nextMarker:
           type: string
+          example: "foobar.mp3"
           description: |-
             If the list of children has been truncated because of its size, a marker will be included in the response.
             You can use the marker in a subsequent request to get the next batch of children.

--- a/openapi/tags/uploads.yaml
+++ b/openapi/tags/uploads.yaml
@@ -285,9 +285,9 @@ paths:
   /v1/uploads/{uuid}/songs:
     parameters:
       - $ref: "#/components/parameters/uploadUUID"
+      - $ref: "./songs.yaml#/components/parameters/query"
       - $ref: "../common/pagination.yaml#/components/parameters/limit"
       - $ref: "../common/pagination.yaml#/components/parameters/offset"
-      - $ref: "./songs.yaml#/components/parameters/query"
     get:
       operationId: getUploadSongs
       summary: List all Songs in an Upload

--- a/openapi/tags/uploads.yaml
+++ b/openapi/tags/uploads.yaml
@@ -6,6 +6,8 @@ info:
   license:
     name: MIT
     url: https://opensource.org/license/mit/
+
+
 tags:
   - name: upload
     x-displayName: Importing Songs
@@ -24,6 +26,8 @@ tags:
       4. Importing discovered songs via `POST /v1/uploads/{uuid}/import`.
       
       Songs that were not imported will be deleted when the upload gets deleted.
+      
+
 paths:
   /v1/uploads:
     get:
@@ -56,7 +60,9 @@ paths:
                   An array of `Song` resources.
                 items:
                   $ref: '#/components/schemas/Upload'
+        401: { $ref: "../common/problem-details.yaml#/components/responses/Unauthorized" }
         5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+
     post:
       operationId: createUpload
       summary: Create Upload
@@ -77,10 +83,15 @@ paths:
                 uuid: "205F5B79-9B05-4D54-B5A1-4943894E7501"
                 status: "open"
               schema: { $ref: '#/components/schemas/Upload' }
+        401: { $ref: "../common/problem-details.yaml#/components/responses/Unauthorized" }
+        403: { $ref: "../common/problem-details.yaml#/components/responses/PermissionDenied" }
         5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+
+
   /v1/uploads/{uuid}:
     parameters:
       - $ref: "#/components/parameters/uploadUUID"
+
     get:
       operationId: getUpload
       summary: Get Upload by UUID
@@ -96,8 +107,11 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/Upload' }
         400: { $ref: "../common/problem-details.yaml#/components/responses/InvalidUUID" }
+        401: { $ref: "../common/problem-details.yaml#/components/responses/Unauthorized" }
+        403: { $ref: "../common/problem-details.yaml#/components/responses/PermissionDenied" }
         404: { $ref: "#/components/responses/UploadNotFound" }
         5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+
     delete:
       operationId: deleteUpload
       summary: Delete Upload by UUID
@@ -108,7 +122,11 @@ paths:
       responses:
         204: { description: Success }
         400: { $ref: "../common/problem-details.yaml#/components/responses/InvalidUUID" }
+        401: { $ref: "../common/problem-details.yaml#/components/responses/Unauthorized" }
+        403: { $ref: "../common/problem-details.yaml#/components/responses/PermissionDenied" }
         5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+
+
   /v1/uploads/{uuid}/files/{path}:
     parameters:
       - $ref: "#/components/parameters/uploadUUID"
@@ -125,6 +143,7 @@ paths:
         schema:
           type: string
           format: path
+
     get:
       operationId: getUploadFile
       summary: Get File Info in an Upload
@@ -180,9 +199,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/File'
         400: { $ref: "#/components/responses/InvalidPathOrUUID" }
+        401: { $ref: "../common/problem-details.yaml#/components/responses/Unauthorized" }
+        403: { $ref: "../common/problem-details.yaml#/components/responses/PermissionDenied" }
         404: { $ref: "#/components/responses/FileOrUploadNotFound" }
         409: { $ref: "#/components/responses/UploadStateError" }
         5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+
     put:
       operationId: replaceUploadFile
       summary: Upload a File into an Upload
@@ -209,9 +231,12 @@ paths:
           x-summary: Success
           description: The file was successfully uploaded.
         400: { $ref: "#/components/responses/InvalidPathOrUUID" }
+        401: { $ref: "../common/problem-details.yaml#/components/responses/Unauthorized" }
+        403: { $ref: "../common/problem-details.yaml#/components/responses/PermissionDenied" }
         404: { $ref: "#/components/responses/UploadNotFound" }
         409: { $ref: "#/components/responses/UploadStateError" }
         5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+
     delete:
       operationId: deleteUploadFile
       summary: Delete a File from an Upload
@@ -226,12 +251,17 @@ paths:
       responses:
         204: { description: Success }
         400: { $ref: "#/components/responses/InvalidPathOrUUID" }
+        401: { $ref: "../common/problem-details.yaml#/components/responses/Unauthorized" }
+        403: { $ref: "../common/problem-details.yaml#/components/responses/PermissionDenied" }
         404: { $ref: "#/components/responses/UploadNotFound" }
         409: { $ref: "#/components/responses/UploadStateError" }
         5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+
+
   /v1/uploads/{uuid}/mark-for-processing:
     parameters:
       - $ref: "#/components/parameters/uploadUUID"
+
     post:
       operationId: markForProcessing
       summary: Mark an Upload for Processing
@@ -251,12 +281,17 @@ paths:
               schema:
                 $ref: '#/components/schemas/Upload'
         400: { $ref: "../common/problem-details.yaml#/components/responses/InvalidUUID" }
+        401: { $ref: "../common/problem-details.yaml#/components/responses/Unauthorized" }
+        403: { $ref: "../common/problem-details.yaml#/components/responses/PermissionDenied" }
         404: { $ref: "#/components/responses/UploadNotFound" }
         409: { $ref: "#/components/responses/UploadStateError" }
         5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+
+
   /v1/uploads/{uuid}/start-processing:
     parameters:
       - $ref: "#/components/parameters/uploadUUID"
+
     post:
       operationId: startProcessing
       summary: Begin Processing an Upload
@@ -279,15 +314,20 @@ paths:
               schema:
                 $ref: '#/components/schemas/Upload'
         400: { $ref: "../common/problem-details.yaml#/components/responses/InvalidUUID" }
+        401: { $ref: "../common/problem-details.yaml#/components/responses/Unauthorized" }
+        403: { $ref: "../common/problem-details.yaml#/components/responses/PermissionDenied" }
         404: { $ref: "#/components/responses/UploadNotFound" }
         409: { $ref: "#/components/responses/UploadStateError" }
         5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+
+
   /v1/uploads/{uuid}/songs:
     parameters:
       - $ref: "#/components/parameters/uploadUUID"
       - $ref: "./songs.yaml#/components/parameters/query"
       - $ref: "../common/pagination.yaml#/components/parameters/limit"
       - $ref: "../common/pagination.yaml#/components/parameters/offset"
+
     get:
       operationId: getUploadSongs
       summary: List all Songs in an Upload
@@ -316,9 +356,13 @@ paths:
                 items:
                   $ref: "songs.yaml#/components/schemas/Song"
         400: { $ref: "../common/problem-details.yaml#/components/responses/InvalidUUID" }
+        401: { $ref: "../common/problem-details.yaml#/components/responses/Unauthorized" }
+        403: { $ref: "../common/problem-details.yaml#/components/responses/PermissionDenied" }
         404: { $ref: "#/components/responses/UploadNotFound" }
         409: { $ref: "#/components/responses/UploadStateError" }
         5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+
+
   /v1/uploads/{uuid}/errors:
     parameters:
       - $ref: "#/components/parameters/uploadUUID"
@@ -348,12 +392,17 @@ paths:
                 items:
                   $ref: "#/components/schemas/UploadError"
         400: { $ref: "../common/problem-details.yaml#/components/responses/InvalidUUID" }
+        401: { $ref: "../common/problem-details.yaml#/components/responses/Unauthorized" }
+        403: { $ref: "../common/problem-details.yaml#/components/responses/PermissionDenied" }
         404: { $ref: "#/components/responses/UploadNotFound" }
         409: { $ref: "#/components/responses/UploadStateError" }
         5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+
+
   /v1/uploads/{uuid}/import:
     parameters:
       - $ref: "#/components/parameters/uploadUUID"
+
     post:
       operationId: importSongs
       summary: Import songs
@@ -379,6 +428,7 @@ paths:
                     format: uuid
       responses: { } # TODO
 
+
 components:
   parameters:
     uploadUUID:
@@ -391,6 +441,8 @@ components:
       example: "A37FCD49-40A2-4FB4-83AA-49A57B62317F"
       description: |-
         The UUID of the upload to operate on.
+        
+
   schemas:
     Upload:
       type: object
@@ -425,6 +477,7 @@ components:
           description: |-
             The `open` status indicates that the upload accepts file uploads and deletes.
             An upload in this status will not be processed automatically.
+
     PendingUpload:
       type: object
       required: [ uuid, status ]
@@ -440,6 +493,7 @@ components:
           description: |-
             The `pending` status indicates that the upload has been marked for processing but processing has not started yet.
             An upload in this status will not accept file uploads.
+
     ProcessingUpload:
       type: object
       required: [ uuid, status, songsTotal, songsProcessed ]
@@ -588,6 +642,7 @@ components:
               example: "205F5B79-9B05-4D54-B5A1-4943894E7501"
               description: |-
                 The requested UUID for which no upload was found.
+
     UploadStateError:
       title: Invalid Upload State
       example:
@@ -609,6 +664,8 @@ components:
               example: "205F5B79-9B05-4D54-B5A1-4943894E7501"
               description: |-
                 The UUID of the affected upload.
+                
+
   responses:
     UploadNotFound:
       x-summary: Not Found
@@ -617,6 +674,7 @@ components:
       content:
         application/problem+json:
           schema: { $ref: "#/components/schemas/UploadNotFoundError" }
+
     FileOrUploadNotFound:
       x-summary: Not Found
       description: |-
@@ -653,6 +711,7 @@ components:
                         example: "some/path"
                         description: |-
                           The path that was requested but at which no file was found.
+
     InvalidPathOrUUID:
       x-summary: Bad Request
       description: |-
@@ -692,6 +751,7 @@ components:
                         example: "some:invalid/path"
                         description: |-
                           The path that was requested but rejected.
+
     UploadStateError:
       x-summary: Conflict
       description: |-

--- a/openapi/tags/user.yaml
+++ b/openapi/tags/user.yaml
@@ -1,0 +1,571 @@
+openapi: 3.0.3
+info:
+  title: User Management
+  version: v1
+  license:
+    name: MIT
+    url: https://opensource.org/license/mit/
+tags:
+  - name: user
+    x-displayName: User Management
+    description: |-
+      These API endpoints can be used to manage the user accounts of Karman.
+      Users in Karman have two identifying properties: A username and a UUID.
+      The username is the primary way of identifying a user, but a username can change.
+      The UUID of a user is fixed and will remain constant even through username changes.
+      
+      User management can be supplemented by additional technologies such as LDAP.
+      These may impact the availability of some of the endpoints below.
+      If an endpoint is disabled due to to server configuration, a 403 response will be generated for these endpoints.
+paths:
+  /v1/users:
+    post:
+      operationId: createUser
+      summary: Create User
+      tags: [ user ]
+      description: |-
+        Create a new user account.
+        The specified username must be unique.
+        The new user will have a randomly generated password and will not be able to sign in
+        unless other authentication methods are available.
+        Use the `/v1/users/{id}/password` endpoint to set a password manually.
+      requestBody:
+        description: |-
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: "#/components/schemas/User"
+                - type: object
+                  required: [ uuid, username ]
+      responses:
+        201:
+          x-summary: Success
+          description: |-
+            The user was created successfully.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/User" }
+        400: { $ref: "../common/problem-details.yaml#/components/responses/BadRequest" }
+        403: { $ref: "#/components/responses/EndpointDisabled" }
+        409: { $ref: "#/components/responses/UsernameNotAvailable" }
+        422: { $ref: "../common/problem-details.yaml#/components/responses/UnprocessableEntity" }
+        5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+    get:
+      operationId: listUsers
+      summary: List Users
+      tags: [ user ]
+      description: |-
+        List all users Karman knows about.
+      parameters:
+        - in: query
+          name: search
+          required: false
+          schema: { type: string }
+          example: "foobar"
+          description: |-
+            A search string.
+            Searches do not only match against usernames but may match additional attributes as well (such as emails).
+        - $ref: "../common/pagination.yaml#/components/parameters/limit"
+        - $ref: "../common/pagination.yaml#/components/parameters/offset"
+      responses:
+        200:
+          x-summary: Success
+          description: |-
+            A successful request returns a paginated collection of users.
+            If the search filter did not match any users, the results will be empty.
+            A `404` status code will not be returned.
+          headers:
+            Pagination-Count: { $ref: "../common/pagination.yaml#/components/headers/Pagination-Count" }
+            Pagination-Offset: { $ref: "../common/pagination.yaml#/components/headers/Pagination-Offset" }
+            Pagination-Limit: { $ref: "../common/pagination.yaml#/components/headers/Pagination-Limit" }
+            Pagination-Total: { $ref: "../common/pagination.yaml#/components/headers/Pagination-Total" }
+          content:
+            application/json:
+              schema:
+                type: array
+                description: |-
+                  An array of `User` resources.
+                items:
+                  $ref: '#/components/schemas/User'
+        5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+  /v1/users/{id}:
+    parameters:
+      - $ref: "#/components/parameters/userID"
+    get:
+      operationId: getUser
+      summary: Get User
+      tags: [ user ]
+      description: |-
+        Fetch information about a single user.
+      responses:
+        200:
+          x-summary: Success
+          description: |-
+            When the request completes successfully the response contains the requested user resource.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/User' }
+        404: { $ref: "#/components/responses/UserNotFound" }
+        5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+    patch:
+      operationId: updateUser
+      summary: Update User
+      tags: [ user ]
+      description: |-
+        Perform a partial update of the user.
+        Only fields present in the request will be updated.
+      requestBody:
+        description: |-
+          The request body contains the fields you want to update.
+          Not all fields may be able to be updated at the same time.
+          If fields cannot be updated simultaneously, a 422 error will be returned.
+          
+          The `username` must be updated individually and cannot be updated with other fields.
+          
+          Changing the `email` will immediately perform an update without verification.
+          In most cases the `/v1/users/{id}/email` endpoint should be preferred.
+        required: true
+        content:
+          application/json:
+            examples:
+              updateUsername:
+                summary: Change Username
+                description: |-
+                  Change the username of a user.
+                value:
+                  username: "wario"
+              updateEmail:
+                summary: Update E-Mail Address
+                description: |-
+                  Change the E-Mail address of a user.
+                value:
+                  email: "wario@example.com"
+              disableUser:
+                summary: Disable a User
+                description: |-
+                  Set a user inactive.
+                value:
+                  active: false
+            schema: { $ref: '#/components/schemas/User' }
+      responses:
+        204:
+          x-summary: No Content
+          description: |-
+            This response indicates that the update was successful.
+        400: { $ref: "../common/problem-details.yaml#/components/responses/BadRequest" }
+        403: { $ref: "#/components/responses/EndpointDisabled" }
+        409: { $ref: "#/components/responses/UsernameNotAvailable" }
+        422: { $ref: "../common/problem-details.yaml#/components/responses/UnprocessableEntity" }
+        5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+    delete:
+      operationId: deleteUser
+      summary: Delete User
+      tags: [ user ]
+      description: |-
+        Deletes the user with the specified `id`.
+        If no user with the requested `id` exists, the response will have code `204`.
+      responses:
+        202:
+          x-summary: Accepted
+          description: |-
+            This response indicates that the deletion request was successful.
+            The user may not be deleted instantly.
+            The deletion cannot be reversed at this point.
+        403: { $ref: "#/components/responses/EndpointDisabled" }
+        5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+  /v1/users/{id}/password:
+    parameters:
+      - $ref: "#/components/parameters/userID"
+    post:
+      operationId: updatePassword
+      summary: Update a Password
+      tags: [ user ]
+      description: |-
+        This endpoint handles password changes by users or admins.
+        A successful request to this endpoint immediately changes the password.
+      requestBody:
+        description: |-
+          The request contains information about the password change.
+        required: true
+        content:
+          application/json:
+            examples:
+              changeKnownPassword:
+                summary: Change a known Password
+                description: |-
+                  Users can change their password by providing the current password.
+                value:
+                  oldPassword: "hunter2"
+                  newPassword: "hunter3"
+              passwordReset:
+                summary: Complete Password Reset
+                description: |-
+                  Complete a password reset.
+                value:
+                  token: "6b5d5b038aa48ce99844515dcee97a0ac435c43d"
+                  newPassword: "hunter3"
+            schema:
+              type: object
+              title: Password Change
+              required: [ newPassword ]
+              properties:
+                token:
+                  type: string
+                  example: "6b5d5b038aa48ce99844515dcee97a0ac435c43d"
+                  description: |-
+                    A password reset token for the user.
+                    If the user does not have admin privileges either `token` or `oldPassword` is required.
+                oldPassword:
+                  type: string
+                  minLength: 6
+                  example: "hunter2"
+                  description: |-
+                    The current password of the user.
+                    If the user does not have admin privileges either `token` or `oldPassword` is required.
+                newPassword:
+                  type: string
+                  minLength: 6
+                  example: "hunter3"
+                  description: |-
+                    The new password for the user.
+      responses:
+        204: { description: Success }
+        400: { $ref: "../common/problem-details.yaml#/components/responses/BadRequest" }
+        404: { $ref: "#/components/responses/UserNotFound" }
+        403:
+          x-summary: Forbidden
+          description: |-
+            Either the provided credentials are not valid or the endpoint is disabled on the server.
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/InvalidCredentials"
+                  - $ref: "../common/problem-details.yaml#/components/schemas/EndpointDisabledError"
+        422: { $ref: "../common/problem-details.yaml#/components/responses/UnprocessableEntity" }
+        5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+  /v1/users/password-reset:
+    post:
+      operationId: resetPassword
+      summary: Reset a Password
+      tags: [ user ]
+      description: |-
+        This endpoint initiates a password reset.
+        As opposed to a password change this will generate a password reset token that can then be used to change the password.
+        This endpoint should be used for a "Forgot Password" functionality.
+        
+        The password reset token will be sent to the user in the form of a link.
+        The link can be specified by the caller of this endpoint, however link targets must be whitelisted on the server to be accepted.
+        The password reset token as well as the user UUID will be appended as URL parameters.
+      requestBody:
+        description: |-
+          The request must contain some information about the user whose password should be reset.
+        required: true
+        content:
+          application/json:
+            examples:
+              resetByUsername:
+                summary: Reset By Username
+                description: |-
+                  Reset the password of a known username
+                value:
+                  username: mario
+                  linkURL: "https://example.com/reset-password"
+              resetByEmail:
+                summary: Reset By Email
+                description: |-
+                  Reset the password of a known email
+                value:
+                  email: "mario@example.com"
+                  linkURL: "https://example.com/reset-password"
+            schema:
+              type: object
+              title: Password Reset
+              required: [ linkURL ]
+              properties:
+                uuid:
+                  type: string
+                  format: uuid
+                  example: "9A9C79B6-A2D1-4968-9A0D-AA6479542114"
+                  description: |-
+                    The UUID of the user whose password should be reset.
+                    Exactly one of `username`, `uuid`, or `email` is required.
+                username:
+                  type: string
+                  minLength: 3
+                  example: "mario"
+                  description: |-
+                    The username whose password should be reset.
+                    Exactly one of `username`, `uuid`, or `email` is required.
+                email:
+                  type: string
+                  format: email
+                  minLength: 3
+                  example: "mario@example.com"
+                  description: |-
+                    The email of the user whose password should be reset.
+                    Exactly one of `username`, `uuid`, or `email` is required.
+                linkURL:
+                  type: string
+                  format: url
+                  minLength: 10
+                  example: "https://example.com/password-reset-callback"
+                  description: |-
+                    The URL that will be sent to the user to perform a password reset.
+                    The following query parameters will be added to this url:
+                    
+                    - `uuid`: The UUID of the user.
+                    - `token`: A password reset token that can be used on the `/v1/users/{id}/password` endpoint.
+                    
+                    A URL used here must be whitelistet by the server.
+      responses:
+        202:
+          x-summary: Success
+          description: |-
+            The password reset has been initiated successfully.
+            This response does not indicate that the password reset link has already reached the user.
+        400: { $ref: "../common/problem-details.yaml#/components/responses/BadRequest" }
+        404: { $ref: "#/components/responses/UserNotFound" }
+        403:
+          x-summary: Forbidden
+          description: |-
+            Either the requested `linkURL` is not whitelisted for password resets or
+            the password reset endpoint is disabled on the server.
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                  - type: object
+                    title: URL Not Whitelisted
+                    example:
+                      type: "codello.dev/karman/problems/forbidden-password-reset-url"
+                      title: "Password Reset URL not Allowed"
+                      status: 403
+                      detail: "The requested password reset URL has not been whitelisted on the server."
+                    allOf:
+                      - $ref: "../common/problem-details.yaml#/components/schemas/ProblemDetails"
+                  - $ref: "../common/problem-details.yaml#/components/schemas/EndpointDisabledError"
+        422: { $ref: "../common/problem-details.yaml#/components/responses/UnprocessableEntity" }
+        5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+  /v1/users/{id}/email:
+    parameters:
+      - $ref: "#/components/parameters/userID"
+    post:
+      operationId: UpdateEmail
+      summary: Change E-Mail
+      tags: [ user ]
+      description: |-
+        This endpoint updates the E-Mail of a user.
+        An email update is not immediate but requires a confirmation.
+      requestBody:
+        description: |-
+          This endpoint has two forms:
+
+          - If no `token` is present, an email update request is created.
+            This causes a verification email to be sent to the email.
+            The verification email contains a link constructed from the provided `linkURL`.
+          - If a `token` is present, this endpoint verifies the token and - if it is valid - updates the user's email.
+        required: true
+        content:
+          application/json:
+            examples:
+              newEmail:
+                summary: Initiate E-Mail Confirmation
+                description: |-
+                  Send a confirmation email to the new address.
+                value:
+                  email: "wario@example.com"
+                  linkURL: "https://example.com/confirm-email"
+              confirmEmail:
+                summary: Confirm a new E-Mail
+                description: |-
+                  Confirm a previously requested E-Mail.
+                value:
+                  email: "wario@example.com"
+                  token: "447118706cefd63bd372a4025e256dfff6cb0ede"
+            schema:
+              type: object
+              title: E-Mail Change
+              required: [ email ]
+              properties:
+                email:
+                  type: string
+                  format: email
+                  minLength: 3
+                  example: "wario@example.com"
+                  description: |-
+                    The new email that is requested.
+                token:
+                  type: string
+                  example: "447118706cefd63bd372a4025e256dfff6cb0ede"
+                  description: |-
+                    An email confirmation token.
+                    If this is present and valid, the user's email is updated immediately.
+                linkURL:
+                  type: string
+                  format: url
+                  example: "https://example.com/confirm-email"
+                  description: |-
+                    The URL that will be sent to the user to confirm the email.
+                    The following query parameters will be added to this url:
+                    
+                    - `uuid`: The UUID of the user.
+                    - `token`: An email confirmation token that can be used to confirm the updated email.
+                    
+                    A URL used here must be whitelisted by the server.
+                    
+                    The `linkURL` is required if no `token` is specified.
+      responses:
+        202:
+          x-summary: Accepted
+          description: |-
+            The request was accepted and a confirmation email was sent.
+            This response does not indicate that the confirmation email has already reached the user.
+        204:
+          x-summary: Success
+          description: |-
+            The email was changed successfully.
+        400: { $ref: "../common/problem-details.yaml#/components/responses/BadRequest" }
+        404: { $ref: "#/components/responses/UserNotFound" }
+        403:
+          x-summary: Forbidden
+          description: |-
+            Either the provided `token` was not valid or the endpoint is disabled on the server.
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/InvalidCredentials"
+                  - $ref: "../common/problem-details.yaml#/components/schemas/EndpointDisabledError"
+        422: { $ref: "../common/problem-details.yaml#/components/responses/UnprocessableEntity" }
+        5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+components:
+  parameters:
+    userID:
+      in: path
+      name: id
+      required: true
+      schema: { type: string }
+      example: "mario"
+      description: |-
+        An identification of the user. This can be:
+        
+        - The special parameter `"me"` identifying user performing the request.
+        - The `uuid` of the user
+        - The `username` of the user
+        
+        Values are matched in this order.
+        In particular UUID-based lookups take precedence over username based lookups.
+  schemas:
+    User:
+      type: object
+      x-tags: [ user ]
+      description: |-
+        A single User.
+      required: [ uuid ]
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          minLength: 36
+          maxLength: 36
+          example: "A37FCD49-40A2-4FB4-83AA-49A57B62317F"
+          readOnly: true
+          description: |-
+            The UUID of the user.
+            The UUID uniquely identifies a user even through username changes.
+        username:
+          type: string
+          minLength: 3
+          example: "mario"
+          description: |-
+            The username of this user.
+            This should be the primary way of user identification
+            The username can be displayed in the UI to identify different users.
+        active:
+          type: boolean
+          example: true
+          description: |-
+            The state of the user.
+            If `active` is `false` the user is disabled and cannot sign in.
+        email:
+          type: string
+          format: email
+          example: "mario@example.com"
+          description: |-
+            The E-Mail address of the user.
+            This field is only included in responses if the requesting user has permissions to view the address.
+    InvalidCredentials:
+      title: Invalid Credentials
+      example:
+        type: "codello.dev/karman/problems/invalid-credentials"
+        title: "Invalid Credentials"
+        status: 403
+      allOf:
+        - $ref: "../common/problem-details.yaml#/components/schemas/ProblemDetails"
+  responses:
+    UsernameNotAvailable:
+      x-summary: Conflict
+      description: |-
+        The requested username is already in use by a different user.
+      content:
+        application/problem+json:
+          schema:
+            title: Username Not Available
+            example:
+              type: "codello.dev/karman/problems/username-not-available"
+              title: "Username Not Available"
+              status: 409
+              detail: "This username is already taken."
+              username: "wario"
+            allOf:
+              - $ref: "../common/problem-details.yaml#/components/schemas/ProblemDetails"
+              - type: object
+                properties:
+                  username:
+                    type: string
+                    minLength: 3
+                    example: "wario"
+                    description: |-
+                      The requested username that was already taken.
+    UserNotFound:
+      x-summary: Not Found
+      description: |-
+        The requested user was not found.
+      content:
+        application/problem+json:
+          schema:
+            title: User Not Found
+            example:
+              type: "codello.dev/karman/problems/user-not-found"
+              title: "User Not Found"
+              status: 404
+              username: "maro"
+            allOf:
+              - $ref: "../common/problem-details.yaml#/components/schemas/ProblemDetails"
+              - type: object
+                properties:
+                  uuid:
+                    type: string
+                    format: uuid
+                    minLength: 36
+                    maxLength: 36
+                    example: "F0481266-E081-4E28-BB20-4D6221C90C2F"
+                    description: |-
+                      The requested UUID for which no user was found.
+                      Only included if a UUID-based lookup was performed.
+                  username:
+                    type: string
+                    example: "maro"
+                    description: |-
+                      The requested username for which no user was found.
+                      Only included if a username-based lookup was performed.
+    EndpointDisabled:
+      x-summary: Endpoint Disabled
+      description: |-
+        This error indicates that the endpoint is disabled due to server configuration.
+      content:
+        application/problem+json:
+          schema: { $ref: "../common/problem-details.yaml#/components/schemas/EndpointDisabledError" }

--- a/openapi/tags/user.yaml
+++ b/openapi/tags/user.yaml
@@ -61,11 +61,9 @@ paths:
       operationId: listUsers
       summary: List Users
       tags: [ user ]
-      security:
-        - {}
-        - OAuth2: []
       description: |-
         List all users Karman knows about.
+        Depending on the user performing the request, some fields may be omitted from the results.
       parameters:
         - in: query
           name: search
@@ -98,6 +96,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/User'
         401: { $ref: "../common/problem-details.yaml#/components/responses/Unauthorized" }
+        403: { $ref: "../common/problem-details.yaml#/components/responses/PermissionDenied" }
         5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
 
 
@@ -109,11 +108,9 @@ paths:
       operationId: getUser
       summary: Get User
       tags: [ user ]
-      security:
-        - {}
-        - OAuth2: []
       description: |-
         Fetch information about a single user.
+        Depending on the user performing the request, some fields may be omitted from the results.
       responses:
         200:
           x-summary: Success

--- a/openapi/tags/user.yaml
+++ b/openapi/tags/user.yaml
@@ -246,14 +246,14 @@ paths:
                     If the user does not have admin privileges either `token` or `oldPassword` is required.
                 oldPassword:
                   type: string
-                  minLength: 6
+                  minLength: 1
                   example: "hunter2"
                   description: |-
                     The current password of the user.
                     If the user does not have admin privileges either `token` or `oldPassword` is required.
                 newPassword:
                   type: string
-                  minLength: 6
+                  minLength: 1
                   example: "hunter3"
                   description: |-
                     The new password for the user.
@@ -317,7 +317,7 @@ paths:
                     Exactly one of `username`, `uuid`, or `email` is required.
                 username:
                   type: string
-                  minLength: 3
+                  minLength: 1
                   example: "mario"
                   description: |-
                     The username whose password should be reset.
@@ -325,7 +325,7 @@ paths:
                 email:
                   type: string
                   format: email
-                  minLength: 3
+                  minLength: 1
                   example: "mario@example.com"
                   description: |-
                     The email of the user whose password should be reset.
@@ -418,7 +418,7 @@ paths:
                 email:
                   type: string
                   format: email
-                  minLength: 3
+                  minLength: 1
                   example: "wario@example.com"
                   description: |-
                     The new email that is requested.
@@ -475,7 +475,8 @@ paths:
                       email:
                         type: string
                         format: email
-                        minLength: 3
+                        minLength: 1
+                        example: "mario@example.com"
                         description: |-
                           The E-Mail address that is already in use.
         422: { $ref: "../common/problem-details.yaml#/components/responses/UnprocessableEntity" }
@@ -507,7 +508,6 @@ components:
       x-tags: [ user ]
       description: |-
         A single User.
-      required: [ uuid ]
       properties:
         uuid:
           type: string
@@ -521,7 +521,7 @@ components:
             The UUID uniquely identifies a user even through username changes.
         username:
           type: string
-          minLength: 3
+          minLength: 1
           example: "mario"
           description: |-
             The username of this user.
@@ -563,7 +563,7 @@ components:
                 properties:
                   username:
                     type: string
-                    minLength: 3
+                    minLength: 1
                     example: "wario"
                     description: |-
                       The requested username that was already taken.
@@ -600,14 +600,6 @@ components:
                     description: |-
                       The requested username for which no user was found.
                       Only included if a username-based lookup was performed.
-
-    EndpointDisabled:
-      x-summary: Endpoint Disabled
-      description: |-
-        This error indicates that the endpoint is disabled due to server configuration.
-      content:
-        application/problem+json:
-          schema: { $ref: "../common/problem-details.yaml#/components/schemas/EndpointDisabledError" }
 
     PermissionDeniedOrEndpointDisabled:
       x-summary: Forbidden

--- a/openapi/tags/user.yaml
+++ b/openapi/tags/user.yaml
@@ -5,6 +5,8 @@ info:
   license:
     name: MIT
     url: https://opensource.org/license/mit/
+
+
 tags:
   - name: user
     x-displayName: User Management
@@ -17,6 +19,8 @@ tags:
       User management can be supplemented by additional technologies such as LDAP.
       These may impact the availability of some of the endpoints below.
       If an endpoint is disabled due to to server configuration, a 403 response will be generated for these endpoints.
+      
+
 paths:
   /v1/users:
     post:
@@ -48,14 +52,18 @@ paths:
             application/json:
               schema: { $ref: "#/components/schemas/User" }
         400: { $ref: "../common/problem-details.yaml#/components/responses/BadRequest" }
-        403: { $ref: "#/components/responses/EndpointDisabled" }
+        403: { $ref: "#/components/responses/PermissionDeniedOrEndpointDisabled" }
         409: { $ref: "#/components/responses/UsernameNotAvailable" }
         422: { $ref: "../common/problem-details.yaml#/components/responses/UnprocessableEntity" }
         5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+
     get:
       operationId: listUsers
       summary: List Users
       tags: [ user ]
+      security:
+        - {}
+        - OAuth2: []
       description: |-
         List all users Karman knows about.
       parameters:
@@ -89,14 +97,21 @@ paths:
                   An array of `User` resources.
                 items:
                   $ref: '#/components/schemas/User'
+        401: { $ref: "../common/problem-details.yaml#/components/responses/Unauthorized" }
         5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+
+
   /v1/users/{id}:
     parameters:
       - $ref: "#/components/parameters/userID"
+
     get:
       operationId: getUser
       summary: Get User
       tags: [ user ]
+      security:
+        - {}
+        - OAuth2: []
       description: |-
         Fetch information about a single user.
       responses:
@@ -108,7 +123,10 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/User' }
         404: { $ref: "#/components/responses/UserNotFound" }
+        401: { $ref: "../common/problem-details.yaml#/components/responses/Unauthorized" }
+        403: { $ref: "../common/problem-details.yaml#/components/responses/PermissionDenied" }
         5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+
     patch:
       operationId: updateUser
       summary: Update User
@@ -155,10 +173,12 @@ paths:
           description: |-
             This response indicates that the update was successful.
         400: { $ref: "../common/problem-details.yaml#/components/responses/BadRequest" }
-        403: { $ref: "#/components/responses/EndpointDisabled" }
+        401: { $ref: "../common/problem-details.yaml#/components/responses/Unauthorized" }
+        403: { $ref: "#/components/responses/PermissionDeniedOrEndpointDisabled" }
         409: { $ref: "#/components/responses/UsernameNotAvailable" }
         422: { $ref: "../common/problem-details.yaml#/components/responses/UnprocessableEntity" }
         5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+
     delete:
       operationId: deleteUser
       summary: Delete User
@@ -173,15 +193,22 @@ paths:
             This response indicates that the deletion request was successful.
             The user may not be deleted instantly.
             The deletion cannot be reversed at this point.
-        403: { $ref: "#/components/responses/EndpointDisabled" }
+        401: { $ref: "../common/problem-details.yaml#/components/responses/Unauthorized" }
+        403: { $ref: "#/components/responses/PermissionDeniedOrEndpointDisabled" }
         5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+
+
   /v1/users/{id}/password:
     parameters:
       - $ref: "#/components/parameters/userID"
+
     post:
       operationId: updatePassword
       summary: Update a Password
       tags: [ user ]
+      security:
+        - {}
+        - OAuth2: []
       description: |-
         This endpoint handles password changes by users or admins.
         A successful request to this endpoint immediately changes the password.
@@ -234,23 +261,19 @@ paths:
         204: { description: Success }
         400: { $ref: "../common/problem-details.yaml#/components/responses/BadRequest" }
         404: { $ref: "#/components/responses/UserNotFound" }
-        403:
-          x-summary: Forbidden
-          description: |-
-            Either the provided credentials are not valid or the endpoint is disabled on the server.
-          content:
-            application/problem+json:
-              schema:
-                oneOf:
-                  - $ref: "#/components/schemas/InvalidCredentials"
-                  - $ref: "../common/problem-details.yaml#/components/schemas/EndpointDisabledError"
+        401: { $ref: "../common/problem-details.yaml#/components/responses/Unauthorized" }
+        403: { $ref: "#/components/responses/PermissionDeniedOrEndpointDisabled" }
         422: { $ref: "../common/problem-details.yaml#/components/responses/UnprocessableEntity" }
         5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+
+
   /v1/users/password-reset:
     post:
       operationId: resetPassword
       summary: Reset a Password
       tags: [ user ]
+      security:
+        - {}
       description: |-
         This endpoint initiates a password reset.
         As opposed to a password change this will generate a password reset token that can then be used to change the password.
@@ -349,6 +372,8 @@ paths:
                   - $ref: "../common/problem-details.yaml#/components/schemas/EndpointDisabledError"
         422: { $ref: "../common/problem-details.yaml#/components/responses/UnprocessableEntity" }
         5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+
+
   /v1/users/{id}/email:
     parameters:
       - $ref: "#/components/parameters/userID"
@@ -428,19 +453,35 @@ paths:
           description: |-
             The email was changed successfully.
         400: { $ref: "../common/problem-details.yaml#/components/responses/BadRequest" }
+        401: { $ref: "../common/problem-details.yaml#/components/responses/Unauthorized" }
+        403: { $ref: "#/components/responses/PermissionDeniedOrEndpointDisabled" }
         404: { $ref: "#/components/responses/UserNotFound" }
-        403:
-          x-summary: Forbidden
+        409:
+          x-summary: Conflict
           description: |-
-            Either the provided `token` was not valid or the endpoint is disabled on the server.
+            The requested email is already in use by another user.
           content:
             application/problem+json:
               schema:
-                oneOf:
-                  - $ref: "#/components/schemas/InvalidCredentials"
-                  - $ref: "../common/problem-details.yaml#/components/schemas/EndpointDisabledError"
+                example:
+                  type: "codello.dev/karman/problems/email-already-in-use"
+                  title: "E-Mail Address Already In Use"
+                  status: 409
+                allOf:
+                  - $ref: "../common/problem-details.yaml#/components/schemas/ProblemDetails"
+                  - type: object
+                    required: [ email ]
+                    properties:
+                      email:
+                        type: string
+                        format: email
+                        minLength: 3
+                        description: |-
+                          The E-Mail address that is already in use.
         422: { $ref: "../common/problem-details.yaml#/components/responses/UnprocessableEntity" }
         5XX: { $ref: "../common/problem-details.yaml#/components/responses/UnexpectedError" }
+
+
 components:
   parameters:
     userID:
@@ -458,6 +499,8 @@ components:
         
         Values are matched in this order.
         In particular UUID-based lookups take precedence over username based lookups.
+        
+
   schemas:
     User:
       type: object
@@ -497,14 +540,8 @@ components:
           description: |-
             The E-Mail address of the user.
             This field is only included in responses if the requesting user has permissions to view the address.
-    InvalidCredentials:
-      title: Invalid Credentials
-      example:
-        type: "codello.dev/karman/problems/invalid-credentials"
-        title: "Invalid Credentials"
-        status: 403
-      allOf:
-        - $ref: "../common/problem-details.yaml#/components/schemas/ProblemDetails"
+
+
   responses:
     UsernameNotAvailable:
       x-summary: Conflict
@@ -530,6 +567,7 @@ components:
                     example: "wario"
                     description: |-
                       The requested username that was already taken.
+
     UserNotFound:
       x-summary: Not Found
       description: |-
@@ -562,6 +600,7 @@ components:
                     description: |-
                       The requested username for which no user was found.
                       Only included if a username-based lookup was performed.
+
     EndpointDisabled:
       x-summary: Endpoint Disabled
       description: |-
@@ -569,3 +608,15 @@ components:
       content:
         application/problem+json:
           schema: { $ref: "../common/problem-details.yaml#/components/schemas/EndpointDisabledError" }
+
+    PermissionDeniedOrEndpointDisabled:
+      x-summary: Forbidden
+      description: |-
+        This error indicates that either the user performing the request does not have the required permissions
+        or the endpoint has been disabled due to server configuration.
+      content:
+        application/problem+json:
+          schema:
+            oneOf:
+              - $ref : "../common/problem-details.yaml#/components/schemas/PermissionDeniedError"
+              - $ref: "../common/problem-details.yaml#/components/schemas/EndpointDisabledError"


### PR DESCRIPTION
This PR introduces user management & authentication in the API. In particular:
- New endpoints are added under `/v1/users/...` for user management
- A new endpoint `/auth/token` is added for login. This endpoint conforms to the OAuth token endpoint mainly for compatibility reasons but this might also make future extension easier. The `authorization_code` grant type is not an intended feature in this PR.
- All existing endpoints are amended with a security scheme as well as appropriate 401 and 403 error responses where applicable.

This PR also fixes some linting errors in the spec and adds whitespace to improve readability.


Related to #5