### PR TITLE
RFC 7807 → RFC 9457

### DIFF
--- a/api/apierror/common.go
+++ b/api/apierror/common.go
@@ -12,16 +12,16 @@ import (
 
 // ProblemTypeDomain is the base domain for all custom problem types.
 // This is the namespace under which all Karman problem types reside.
-const ProblemTypeDomain = "https://codello.dev/karman/problems"
+const ProblemTypeDomain = "tag:codello.dev,2020:karman/problems:"
 
 const (
 	// TypeValidationError indicates a that the request data did not conform to the required schema.
 	// This error should be associated with HTTP status code 422.
-	TypeValidationError = ProblemTypeDomain + "/validation-error"
+	TypeValidationError = ProblemTypeDomain + "validation-error"
 
 	// TypeInvalidUUID indicates that a UUID parameter was not a valid UUID.
 	// This error should be associated with HTTP status code 400.
-	TypeInvalidUUID = ProblemTypeDomain + "/invalid-uuid"
+	TypeInvalidUUID = ProblemTypeDomain + "invalid-uuid"
 )
 
 var (

--- a/api/apierror/doc.go
+++ b/api/apierror/doc.go
@@ -1,9 +1,9 @@
-// Package apierror provides two things: an implementation of [RFC 7807] and
+// Package apierror provides two things: an implementation of [RFC 9457] and
 // convenience functions that generate the errors returned by the Karman API.
 //
-// The ProblemDetails provides an implementation of [RFC 7807].
+// The ProblemDetails provides an implementation of [RFC 9457].
 // You can use it to provide as many or as few details about an error as necessary.
 // This package is intended to be used together with render.Render but can be used on its own as well.
 //
-// [RFC 7807]: https://datatracker.ietf.org/doc/html/rfc7807
+// [RFC 9457]: https://datatracker.ietf.org/doc/html/rfc9457
 package apierror

--- a/api/apierror/httperrors.go
+++ b/api/apierror/httperrors.go
@@ -53,11 +53,25 @@ func UnsupportedMediaType(allowed ...mediatype.MediaType) *ProblemDetails {
 	}
 }
 
-// UnprocessableEntity generates an error indicating that the request payload did not conform to the expected schema.
-func UnprocessableEntity(message string) *ProblemDetails {
-	p := HTTPStatus(http.StatusUnprocessableEntity)
-	p.Detail = message
-	return p
+// ValidationError generates an error indicating that the request payload did not conform to the expected schema.
+func ValidationError(message string, errors map[string]string) *ProblemDetails {
+	err := &ProblemDetails{
+		Type:   TypeValidationError,
+		Title:  "Unprocessable Entity",
+		Status: http.StatusUnprocessableEntity,
+		Detail: message,
+	}
+	if errors != nil {
+		errorList := make([]map[string]string, 0, len(errors))
+		for pointer, msg := range errors {
+			errorList = append(errorList, map[string]string{
+				"pointer": pointer,
+				"message": msg,
+			})
+		}
+		err.Fields = map[string]any{"errors": errorList}
+	}
+	return err
 }
 
 // BadRequest generates an 400 Bad Request error with the specified message.

--- a/api/apierror/httperrors.go
+++ b/api/apierror/httperrors.go
@@ -8,10 +8,10 @@ import (
 
 const (
 	// TypeMissingContentType indicates that a Content-Type header is required but was not specified.
-	TypeMissingContentType = ProblemTypeDomain + "/missing-content-type"
+	TypeMissingContentType = ProblemTypeDomain + "missing-content-type"
 
 	// TypeUnsupportedMediaType indicates that the Content-Type header was valid but the supplied media type is not allowed.
-	TypeUnsupportedMediaType = ProblemTypeDomain + "/unsupported-media-type"
+	TypeUnsupportedMediaType = ProblemTypeDomain + "unsupported-media-type"
 )
 
 // These errors are ProblemDetails representations of common HTTP error codes.

--- a/api/apierror/rfc9457.go
+++ b/api/apierror/rfc9457.go
@@ -8,7 +8,7 @@ import (
 	"github.com/Karaoke-Manager/karman/pkg/render"
 )
 
-// ProblemDetails implements [RFC 7807] "Problem Details for HTTP APIs".
+// ProblemDetails implements [RFC 9457] "Problem Details for HTTP APIs".
 // A ProblemDetails value is intended to be used for error reporting from the Karman API.
 // Problem details are usually categorized by their type which is a URI.
 // This package defines utility functions and constants for typical errors.
@@ -17,7 +17,7 @@ import (
 // A ProblemDetails value is intended to be serialized using the
 // [github.com/Karaoke-Manager/karman/pkg/render] package.
 //
-// [RFC 7807]: https://datatracker.ietf.org/doc/html/rfc7807
+// [RFC 9457]: https://datatracker.ietf.org/doc/html/rfc9457
 type ProblemDetails struct {
 	// A URI reference that identifies the problem type.
 	// When dereferenced it should provide human-readable documentation for the problem type.

--- a/api/apierror/song.go
+++ b/api/apierror/song.go
@@ -12,13 +12,13 @@ import (
 const (
 	// TypeInvalidTXT indicates that the UltraStar txt data could not be parsed.
 	// It is usually accompanied by a line number that caused the error.
-	TypeInvalidTXT = ProblemTypeDomain + "/invalid-ultrastar-txt"
+	TypeInvalidTXT = ProblemTypeDomain + "invalid-ultrastar-txt"
 
 	// TypeUploadSongReadonly indicates that the song cannot be modified because it belongs to an upload.
-	TypeUploadSongReadonly = ProblemTypeDomain + "/upload-song-readonly"
+	TypeUploadSongReadonly = ProblemTypeDomain + "upload-song-readonly"
 
 	// TypeMediaFileNotFound indicates that the requested media file was not found.
-	TypeMediaFileNotFound = ProblemTypeDomain + "/song-media-not-found"
+	TypeMediaFileNotFound = ProblemTypeDomain + "song-media-not-found"
 )
 
 // InvalidUltraStarTXT generates an error indicating that the UltraStar data in the request could not be parsed.

--- a/api/apierror/upload.go
+++ b/api/apierror/upload.go
@@ -10,13 +10,13 @@ import (
 // These constants identify known problem types related to uploads.
 const (
 	// TypeUploadState indicates that a file action to an upload was rejected because the upload has already been marked for processing.
-	TypeUploadState = ProblemTypeDomain + "/upload-state"
+	TypeUploadState = ProblemTypeDomain + "upload-state"
 
 	// TypeUploadFileNotFound indicates that a file was requested from an upload but the file was not found.
-	TypeUploadFileNotFound = ProblemTypeDomain + "/upload-file-not-found"
+	TypeUploadFileNotFound = ProblemTypeDomain + "upload-file-not-found"
 
 	// TypeInvalidUploadPath indicates that the file path within an upload is not a valid path.
-	TypeInvalidUploadPath = ProblemTypeDomain + "/invalid-upload-path"
+	TypeInvalidUploadPath = ProblemTypeDomain + "invalid-upload-path"
 )
 
 // UploadState generates an error indicating that the upload is not in the correct state to perform this action.

--- a/openapi/common/problem-details.yaml
+++ b/openapi/common/problem-details.yaml
@@ -179,18 +179,30 @@ components:
               status: 422
               instance: "/traces/481CF77B-3099-445C-A789-58F997233681"
               fields:
-                medley.medleyStartBeat: "number expected"
+                - pointer: "/gap"
+                  detail: "must be an integer"
             allOf:
               - $ref: "#/components/schemas/ProblemDetails"
               - type: object
                 properties:
-                  fields:
-                    type: object
-                    additionalProperties: { type: string }
+                  errors:
+                    type: array
                     description: |-
-                      A `Unprocessable Entity` response may or may not contain information about the JSON field that caused the error.
-                      
-                      The value of this property is a mapping from field paths to error messages.
+                      A `Unprocessable Entity` response may or may not contain information about the JSON fields that caused the error.
+                    items:
+                      type: object
+                      properties:
+                        pointer:
+                          type: string
+                          format: json-pointer
+                          example: "/gap"
+                          description: |-
+                            A [JSON pointer](https://www.rfc-editor.org/rfc/rfc6901.html) identifying the field in the input that caused the error.
+                        detail:
+                          type: string
+                          example: "must be an integer"
+                          description: |-
+                            A human-readable error message.
 
     UnexpectedError:
       x-summary: Unexpected Error

--- a/openapi/common/problem-details.yaml
+++ b/openapi/common/problem-details.yaml
@@ -16,7 +16,7 @@ components:
           Any error object may contain additional properties specific to the error or error instance.
           Unless documented these additional fields should not be relied upon.
       description: |-
-        A problem details object as specified in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+        A problem details object as specified in [RFC 9457](https://www.rfc-editor.org/rfc/rfc7807).
       required: [ status ]
       properties:
         type:
@@ -55,7 +55,7 @@ components:
     InvalidUUIDError:
       title: Invalid UUID
       example:
-        type: "codello.dev/karman/problems/invalid-uuid"
+        type: "tag:codello.dev,2020:karman/problems:invalid-uuid"
         title: "Invalid UUID"
         status: 400
       allOf:
@@ -73,7 +73,7 @@ components:
     PermissionDeniedError:
       title: PermissionDenied
       example:
-        type: "codello.dev/karman/problems/permission-denied"
+        type: "tag:codello.dev,2020:karman/problems:permission-denied"
         title: "Permission Denied"
         status: 403
         detail: "You must be an administrator to perform this action."
@@ -84,7 +84,7 @@ components:
     EndpointDisabledError:
       title: Endpoint Disabled
       example:
-        type: "codello.dev/karman/problems/endpoint-disabled"
+        type: "tag:codello.dev,2020:karman/problems:endpoint-disabled"
         title: "Endpoint Disabled"
         status: 403
         detail: "This feature has been disabled by the server administrator."
@@ -174,7 +174,7 @@ components:
         application/problem+json:
           schema:
             example:
-              type: "codello.dev/karman/problems/validation-error"
+              type: "tag:codello.dev,2020:karman/problems:validation-error"
               title: "Unprocessable Entity"
               status: 422
               instance: "/traces/481CF77B-3099-445C-A789-58F997233681"

--- a/openapi/tags/media.yaml
+++ b/openapi/tags/media.yaml
@@ -322,7 +322,7 @@ components:
     FileNotFoundError:
       title: Media File Not Found
       example:
-        type: "codello.dev/karman/problems/song-media-not-found"
+        type: "tag:codello.dev,2020:karman/problems:song-media-not-found"
         title: "Media File Not Found"
         status: 404
         detail: "The song has no cover."

--- a/openapi/tags/songs.yaml
+++ b/openapi/tags/songs.yaml
@@ -763,7 +763,7 @@ components:
     SongNotFoundError:
       title: Song Not Found
       example:
-        type: "codello.dev/karman/problems/song-not-found"
+        type: "tag:codello.dev,2020:karman/problems:song-not-found"
         title: "Song Not Found"
         status: 404
         uuid: "F0481266-E081-4E28-BB20-4D6221C90C2F"
@@ -784,7 +784,7 @@ components:
     InvalidTXTError:
       title: Invalid TXT
       example:
-        type: "codello.dev/karman/problems/invalid-ultrastar-txt"
+        type: "tag:codello.dev,2020:karman/problems:invalid-ultrastar-txt"
         title: "Invalid UltraStar TXT"
         status: 400
         detail: "Invalid line break."
@@ -821,7 +821,7 @@ components:
           schema:
             title: Upload Cannot Be Modified
             example:
-              type: "codello.dev/karman/problems/upload-song-readonly"
+              type: "tag:codello.dev,2020:karman/problems:upload-song-readonly"
               title: "A Song in an Upload Cannot Be Modified"
               status: 409
               detail: "The song must be imported before it can be modified."

--- a/openapi/tags/uploads.yaml
+++ b/openapi/tags/uploads.yaml
@@ -651,7 +651,7 @@ components:
     UploadNotFoundError:
       title: Upload Not Found
       example:
-        type: "codello.dev/karman/problems/upload-not-found"
+        type: "tag:codello.dev,2020:karman/problems:upload-not-found"
         title: "Upload Not Found"
         status: 404
         uuid: "F0481266-E081-4E28-BB20-4D6221C90C2F"
@@ -672,7 +672,7 @@ components:
     UploadStateError:
       title: Invalid Upload State
       example:
-        type: "codello.dev/karman/problems/upload-state"
+        type: "tag:codello.dev,2020:karman/problems:upload-state"
         title: "Invalid Upload State"
         detail: "This action cannot be performed in the current upload state."
         status: 409
@@ -712,7 +712,7 @@ components:
               - $ref: "#/components/schemas/UploadNotFoundError"
               - title: File Not Found
                 example:
-                  type: "codello.dev/karman/problems/file-not-found"
+                  type: "tag:codello.dev,2020:karman/problems:file-not-found"
                   title: "File Not Found"
                   status: 404
                   uuid: "F0481266-E081-4E28-BB20-4D6221C90C2F"
@@ -752,7 +752,7 @@ components:
               - $ref: "../common/problem-details.yaml#/components/schemas/InvalidUUIDError"
               - title: Invalid Path
                 example:
-                  type: "codello.dev/karman/problems/invalid-upload-path"
+                  type: "tag:codello.dev,2020:karman/problems:invalid-upload-path"
                   title: "Invalid Path"
                   status: 400
                   uuid: "F0481266-E081-4E28-BB20-4D6221C90C2F"

--- a/openapi/tags/user.yaml
+++ b/openapi/tags/user.yaml
@@ -360,7 +360,7 @@ paths:
                   - type: object
                     title: URL Not Whitelisted
                     example:
-                      type: "codello.dev/karman/problems/forbidden-password-reset-url"
+                      type: "tag:codello.dev,2020:karman/problems:forbidden-password-reset-url"
                       title: "Password Reset URL not Allowed"
                       status: 403
                       detail: "The requested password reset URL has not been whitelisted on the server."
@@ -461,7 +461,7 @@ paths:
             application/problem+json:
               schema:
                 example:
-                  type: "codello.dev/karman/problems/email-already-in-use"
+                  type: "tag:codello.dev,2020:karman/problems:email-already-in-use"
                   title: "E-Mail Address Already In Use"
                   status: 409
                 allOf:
@@ -549,7 +549,7 @@ components:
           schema:
             title: Username Not Available
             example:
-              type: "codello.dev/karman/problems/username-not-available"
+              type: "tag:codello.dev,2020:karman/problems:username-not-available"
               title: "Username Not Available"
               status: 409
               detail: "This username is already taken."
@@ -574,7 +574,7 @@ components:
           schema:
             title: User Not Found
             example:
-              type: "codello.dev/karman/problems/user-not-found"
+              type: "tag:codello.dev,2020:karman/problems:user-not-found"
               title: "User Not Found"
               status: 404
               username: "maro"

--- a/test/errors.go
+++ b/test/errors.go
@@ -50,6 +50,26 @@ func AssertProblemDetails(t *testing.T, resp *http.Response, code int, errType s
 	}
 }
 
+// AssertValidationError validates that resp encodes a problem details instance, indicating a 422 Unprocessable Entity error.
+// It is validated that the error contains the specified error messages.
+// errors maps from expected JSON pointers to their error messages.
+func AssertValidationError(t *testing.T, resp *http.Response, errors map[string]string) {
+	if errors == nil {
+		AssertProblemDetails(t, resp, http.StatusUnprocessableEntity, apierror.TypeValidationError, nil)
+	} else {
+		expectedErrors := make([]any, 0, len(errors))
+		for pointer, message := range errors {
+			expectedErrors = append(expectedErrors, map[string]any{
+				"pointer": pointer,
+				"message": message,
+			})
+		}
+		AssertProblemDetails(t, resp, http.StatusUnprocessableEntity, apierror.TypeValidationError, map[string]any{
+			"errors": expectedErrors,
+		})
+	}
+}
+
 // MissingContentType returns a test that runs a request against h without the Content-Type header
 // and validates that the response indicates as much.
 // The variadic argument lets you specify the expected allowed content types for this endpoint.


### PR DESCRIPTION
RFC 9457 has obsoleted RFC 7807. This PR updates the API spec as well as the code comments accordingly. For now the API uses the ['tag' URI scheme](https://datatracker.ietf.org/doc/html/rfc4151) as we don't currently have a resolvable URL for our documentation. We should update this in the future to a dedicated domain.

This PR also changes the error schema for 422 responses to include a potential list of errors, identifying the fields they where they originate.

Fixes #50 