### PR TITLE
fix: Signaling on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     name: Unit Tests
     uses: codello/.github/.github/workflows/go-test.yml@v1
     with:
-      test-on: ubuntu-latest,ubuntu-20.04,macos-latest
+      test-on: ubuntu-latest,ubuntu-20.04,windows-latest,macos-latest
 
   integration-test:
     name: Integration Tests
@@ -35,7 +35,7 @@ jobs:
     uses: codello/.github/.github/workflows/go-build.yml@v1
     with:
       packages: ./cmd/karman
-      platforms: linux/amd64,linux/arm64,linux/arm,linux/386,darwin/amd64,darwin/arm64
+      platforms: linux/amd64,linux/arm64,linux/arm,linux/386,windows/amd64,darwin/amd64,darwin/arm64
       ldflags: -w -s -X "main.Version=${{ github.ref_type == 'tag' && github.ref_name || '' }}"
 
   publish:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     name: Unit Tests
     uses: codello/.github/.github/workflows/go-test.yml@v1
     with:
-      test-on: ubuntu-latest,ubuntu-20.04,windows-latest,macos-latest
+      test-on: ubuntu-latest,ubuntu-20.04,macos-latest
 
   integration-test:
     name: Integration Tests
@@ -35,7 +35,7 @@ jobs:
     uses: codello/.github/.github/workflows/go-build.yml@v1
     with:
       packages: ./cmd/karman
-      platforms: linux/amd64,linux/arm64,linux/arm,linux/386,windows/amd64,darwin/amd64,darwin/arm64
+      platforms: linux/amd64,linux/arm64,linux/arm,linux/386,darwin/amd64,darwin/arm64
       ldflags: -w -s -X "main.Version=${{ github.ref_type == 'tag' && github.ref_name || '' }}"
 
   publish:

--- a/cmd/karman/internal/asynq.go
+++ b/cmd/karman/internal/asynq.go
@@ -3,7 +3,7 @@ package internal
 import (
 	"fmt"
 	"log/slog"
-	"syscall"
+	"os"
 
 	"github.com/hibiken/asynq"
 )
@@ -22,41 +22,44 @@ func AsynqLogLevel(level slog.Level) asynq.LogLevel {
 
 // AsynqLogger is an implementation of asynq.Logger backed by a slog.Logger.
 // This logger implements the Fatal method by sending a termination signal.
-type AsynqLogger slog.Logger
+type AsynqLogger struct {
+	Logger *slog.Logger     // underlying logger
+	Sig    chan<- os.Signal // termination signal
+}
 
 // Debug logs a message at Debug level.
 func (l *AsynqLogger) Debug(args ...any) {
 	for _, line := range args {
-		(*slog.Logger)(l).Debug(fmt.Sprintf("%s", line))
+		l.Logger.Debug(fmt.Sprintf("%s", line))
 	}
 }
 
 // Info logs a message at Info level.
 func (l *AsynqLogger) Info(args ...any) {
 	for _, line := range args {
-		(*slog.Logger)(l).Info(fmt.Sprintf("%s", line))
+		l.Logger.Info(fmt.Sprintf("%s", line))
 	}
 }
 
 // Warn logs a message at Warning level.
 func (l *AsynqLogger) Warn(args ...any) {
 	for _, line := range args {
-		(*slog.Logger)(l).Warn(fmt.Sprintf("%s", line))
+		l.Logger.Warn(fmt.Sprintf("%s", line))
 	}
 }
 
 // Error logs a message at Error level.
 func (l *AsynqLogger) Error(args ...any) {
 	for _, line := range args {
-		(*slog.Logger)(l).Error(fmt.Sprintf("%s", line))
+		l.Logger.Error(fmt.Sprintf("%s", line))
 	}
 }
 
 // Fatal logs a message at Error level.
-// Additionally Fatal sends a SIGTERM to the current process, leading to the program's termination.
+// Additionally Fatal sends a SIGINT to the current process, leading to the program's termination.
 func (l *AsynqLogger) Fatal(args ...any) {
 	for _, line := range args {
-		(*slog.Logger)(l).Error(fmt.Sprintf("%s", line))
+		l.Logger.Error(fmt.Sprintf("%s", line))
 	}
-	_ = syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
+	l.Sig <- os.Interrupt
 }


### PR DESCRIPTION
This PR fixes the use of `syscall.Kill` on Windows by wiring up the signaling pipeline manually.